### PR TITLE
Correct line wrapping with display width

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,11 +6,17 @@ Version 0.2.0
 
 To be released.
 
+ -  Fixed text wrapping to use Unicode display width instead of byte length.
+    East Asian wide characters (Korean, Japanese, Chinese) are now correctly
+    counted as 2 columns, so text wraps at the correct visual position.
+    [[#3] by Lee Dogeon]
+
  -  Added support for directory arguments.  When a directory is passed as an
     argument, Hongdown now recursively finds all Markdown files (_\*.md_ and
     _\*.markdown_) within it.  [[#2]]
 
 [#2]: https://github.com/dahlia/hongdown/issues/2
+[#3]: https://github.com/dahlia/hongdown/pull/3
 
 
 Version 0.1.0

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -14,6 +14,7 @@ mod wrap;
 pub use state::{ReferenceLink, Serializer, Warning};
 
 use comrak::nodes::{AstNode, NodeValue};
+use unicode_width::UnicodeWidthStr;
 
 use crate::Options;
 
@@ -376,7 +377,7 @@ impl<'a> Serializer<'a> {
         let continuation_indent = " ".repeat(prefix.len());
 
         // Wrap content at 80 chars, accounting for prefix on first line
-        let first_line_width = 80 - prefix.len();
+        let first_line_width = 80 - prefix.width();
         let continuation_width = 80 - continuation_indent.len();
 
         // Replace SoftBreak marker (\x00) with space before processing
@@ -401,7 +402,7 @@ impl<'a> Serializer<'a> {
 
             if current_line.is_empty() {
                 current_line.push_str(word);
-            } else if current_line.len() + 1 + word.len() <= max_width {
+            } else if current_line.width() + 1 + word.width() <= max_width {
                 current_line.push(' ');
                 current_line.push_str(word);
             } else {

--- a/src/serializer/wrap.rs
+++ b/src/serializer/wrap.rs
@@ -1,5 +1,7 @@
 //! Text wrapping utilities for Markdown serialization.
 
+use unicode_width::UnicodeWidthStr;
+
 /// Wrap text at the specified line width.
 ///
 /// This function handles soft break markers (`\x00`) which represent where
@@ -52,7 +54,7 @@ fn wrap_text_segment(text: &str, prefix: &str, line_width: usize) -> String {
 
     while i < original_lines.len() {
         let line = original_lines[i].trim();
-        let line_with_prefix_len = prefix.len() + line.len();
+        let line_with_prefix_len = prefix.width() + line.width();
 
         if line_with_prefix_len <= line_width {
             // Line fits within limit, keep it as-is
@@ -159,7 +161,7 @@ fn wrap_text_first_line_segment(
         } else {
             continuation_prefix
         };
-        let line_with_prefix_len = current_prefix.len() + line.len();
+        let line_with_prefix_len = current_prefix.width() + line.width();
 
         if line_with_prefix_len <= line_width {
             // Line fits within limit, keep it as-is
@@ -209,7 +211,7 @@ pub fn wrap_single_segment(
     let mut result = String::new();
     let mut current_line = String::new();
     let mut is_first_line = true;
-    let first_prefix_len = first_prefix.len();
+    let first_prefix_width = first_prefix.width();
 
     // Add prefix to first line
     current_line.push_str(first_prefix);
@@ -240,7 +242,7 @@ pub fn wrap_single_segment(
                         &mut current_line,
                         &current_token,
                         &trailing_spaces,
-                        first_prefix_len,
+                        first_prefix_width,
                         prefix,
                         line_width,
                         &mut is_first_line,
@@ -263,7 +265,7 @@ pub fn wrap_single_segment(
                     &mut current_line,
                     &current_token,
                     &trailing_spaces,
-                    first_prefix_len,
+                    first_prefix_width,
                     prefix,
                     line_width,
                     &mut is_first_line,
@@ -291,7 +293,7 @@ pub fn wrap_single_segment(
                     &mut current_line,
                     &current_token,
                     &trailing_spaces,
-                    first_prefix_len,
+                    first_prefix_width,
                     prefix,
                     line_width,
                     &mut is_first_line,
@@ -310,7 +312,7 @@ pub fn wrap_single_segment(
             &mut current_line,
             &current_token,
             "",
-            first_prefix_len,
+            first_prefix_width,
             prefix,
             line_width,
             &mut is_first_line,
@@ -332,24 +334,24 @@ fn add_token_to_line_with_prefix(
     current_line: &mut String,
     token: &str,
     trailing_spaces: &str,
-    first_prefix_len: usize,
+    first_prefix_width: usize,
     prefix: &str,
     line_width: usize,
     is_first_line: &mut bool,
 ) {
-    let token_len = token.len();
+    let token_width = token.width();
     let spaces_len = trailing_spaces.len();
-    let current_prefix_len = if *is_first_line {
-        first_prefix_len
+    let current_prefix_width = if *is_first_line {
+        first_prefix_width
     } else {
-        prefix.len()
+        prefix.width()
     };
 
-    if current_line.len() == current_prefix_len {
+    if current_line.width() == current_prefix_width {
         // First word on this line (prefix already added)
         current_line.push_str(token);
         current_line.push_str(trailing_spaces);
-    } else if current_line.len() + token_len + spaces_len <= line_width {
+    } else if current_line.width() + token_width + spaces_len <= line_width {
         // Token fits on current line
         current_line.push_str(token);
         current_line.push_str(trailing_spaces);


### PR DESCRIPTION
Overview
=======

Because the byte length of a Korean word `"안녕"` is `6`[^1], the hongdown wraps lines more early than expected.
According to README, it should be treated as 2 columns instead raw binary size(`3`).

> East Asian wide characters are counted as 2 columns

I see you're already using the `unicode_width` crate for table calculations and have reused it.

[^1]: https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=6a90fd6edb233a769296365b914fba61

Notes on Uncertain Parts
=====================

- This is a good test to demonstrate that Unicode width applies not only to Hangul but also to Chinese and Japanese characters. However, since Chinese and Japanese languages do not actually use spaces in practice, line wrapping may not occur, making it unclear whether the test case is valid. To fundamentally solve this, Unicode UAX 14 (Unicode Line Breaking Algorithm[^2]) would need to be implemented, but since that is outside the scope of this PR, we only need to determine whether the test case is appropriate.

~~~rust
#[test]
fn test_wrap_japanese_text() {
    // Japanese hiragana/katakana/kanji are also 2 display columns each
    // Text with spaces to allow wrapping at word boundaries
    let input = "これは 日本語の テストです 行の折り返しが 正しく動作する";
    let result = parse_and_serialize_with_width(input, 30);
    assert_eq!(
        result,
        r#"
これは 日本語の テストです
行の折り返しが 正しく動作する
"#
        .trim_start_matches('\n')
    );
}
~~~

[^2]: https://www.unicode.org/reports/tr14/
