### PR TITLE
Use display width for Setext heading underlines

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,10 @@ Version 0.2.0
 
 To be released.
 
+ -  Fixed Setext-style heading underlines to match the display width of the
+    heading text.  East Asian wide characters are now correctly counted as
+    2 columns.  [[#5] by Lee Dogeon]
+
  -  Fixed text wrapping to use Unicode display width instead of byte length.
     East Asian wide characters (Korean, Japanese, Chinese) are now correctly
     counted as 2 columns, so text wraps at the correct visual position.
@@ -17,6 +21,7 @@ To be released.
 
 [#2]: https://github.com/dahlia/hongdown/issues/2
 [#3]: https://github.com/dahlia/hongdown/pull/3
+[#5]: https://github.com/dahlia/hongdown/pull/5
 
 
 Version 0.1.0

--- a/STYLE.md
+++ b/STYLE.md
@@ -86,6 +86,11 @@ documentation.
 The underline of a Setext-style heading should match the display width of
 the heading text, accounting for East Asian wide characters.
 
+#### East Asian character width
+
+East Asian wide characters (CJK characters) are counted as two columns when
+calculating the display width.
+
 
 Emphasis
 --------

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -2,6 +2,7 @@
 
 use comrak::nodes::{AstNode, NodeValue};
 use regex::Regex;
+use unicode_width::UnicodeWidthStr;
 
 use super::Serializer;
 use super::state::{Directive, FormatSkipMode};
@@ -374,15 +375,13 @@ impl<'a> Serializer<'a> {
             // Setext-style with '='
             self.output.push_str(&heading_text);
             self.output.push('\n');
-            self.output
-                .push_str(&"=".repeat(heading_text.chars().count()));
+            self.output.push_str(&"=".repeat(heading_text.width()));
             self.output.push('\n');
         } else if level == 2 && self.options.setext_h2 {
             // Setext-style with '-'
             self.output.push_str(&heading_text);
             self.output.push('\n');
-            self.output
-                .push_str(&"-".repeat(heading_text.chars().count()));
+            self.output.push_str(&"-".repeat(heading_text.width()));
             self.output.push('\n');
         } else {
             // ATX-style for level 3+ or when setext is disabled

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -3227,3 +3227,38 @@ fn test_korean_line_exactly_at_width_limit() {
         .trim_start_matches('\n')
     );
 }
+
+// Setext Heading Display Width Tests
+// =============================================================================
+
+#[test]
+fn test_setext_h1_with_fullwidth_characters() {
+    // "한글 제목" = 4 wide chars (8 cols) + 1 space = 9 display columns
+    // Input has 5 chars (character count), output should have 9 (display width)
+    let input = "한글 제목\n=====\n";
+    let result = parse_and_serialize(input);
+    assert_eq!(
+        result,
+        r#"
+한글 제목
+=========
+"#
+        .trim_start_matches('\n')
+    );
+}
+
+#[test]
+fn test_setext_h2_with_fullwidth_characters() {
+    // "한글 제목" = 4 wide chars (8 cols) + 1 space = 9 display columns
+    // Input has 5 chars (character count), output should have 9 (display width)
+    let input = "한글 제목\n-----\n";
+    let result = parse_and_serialize(input);
+    assert_eq!(
+        result,
+        r#"
+한글 제목
+---------
+"#
+        .trim_start_matches('\n')
+    );
+}


### PR DESCRIPTION
From the perspective of consistency and what is actually displayed, I thought it was correct that East Asian wide characters should be counted as 2 columns when calculating the length of setext underlines, just as they are in line wrapping. Therefore, I have added a new `#### East Asian character width` subsection under the `### Underline length` section in *STYLE.md* and also changed the code behavior accordingly.

> The underline of a Setext-style heading should match the display width of the heading text, accounting for East Asian wide characters.

Screenshot
-----------

Editor: Zed
Font Family: Sarasa Mono K

Before:

<img width="148" height="53" alt="image" src="https://github.com/user-attachments/assets/8cb5813b-710d-4e5d-9ef1-519a0824b15e" />

After:

<img width="145" height="58" alt="image" src="https://github.com/user-attachments/assets/83b4efdb-886f-425f-a92c-c2194453dfc4" />

---

Font Family: Sarasa Gothic K

Before:

<img width="161" height="58" alt="image" src="https://github.com/user-attachments/assets/cec2aa8a-ac05-4049-823f-eca30c763c0f" />

After:

<img width="203" height="59" alt="image" src="https://github.com/user-attachments/assets/5b8d2545-b574-4678-bac9-c17ea6f0b6d9" />