### PR TITLE
MDX mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,36 @@ Version 0.5.0
 
 To be released.
 
+ -  Added MDX support.  MDX documents embed JavaScript and JSX that comrak (the
+    underlying CommonMark parser) does not understand, so Hongdown used to
+    mangle them — turning straight quotes into curly quotes, backslash-escaping
+    Markdown punctuation, and collapsing indentation.  When MDX mode is
+    enabled, Hongdown now detects those constructs and preserves them verbatim
+    while still formatting the surrounding Markdown prose.  [[#22]]
+
+    Within Markdown prose, the protected constructs are ESM `import`/`export`
+    statements, JSX elements and fragments, and `{…}` expressions (including JSX
+    comments like `{/* … */}`).  The embedded JavaScript/JSX is preserved as-is,
+    not reformatted; constructs that the underlying parser already handles
+    correctly — such as a valid inline-HTML JSX tag or a `{#id}` heading anchor
+    — are left to it.
+
+    MDX mode is enabled automatically for files with the *.mdx* extension, which
+    are now also discovered when a directory is passed on the command line.  It
+    can be turned on explicitly for stdin or *.md* input with the `--mdx`
+    command-line flag or the `mdx` option in *.hongdown.toml* (Rust API:
+    `Options.mdx`, type `bool`; WASM/JavaScript: `mdx`, type `boolean`).  All
+    default to off, so non-MDX documents are unaffected.
+
+ -  Fixed a bug where a document whose only content was one or more HTML blocks
+    (for example a single HTML comment) gained two spurious leading blank lines.
+
+ -  Fixed a bug where two consecutive trailing HTML blocks that were separated
+    by a blank line in the source were emitted on adjacent lines, dropping the
+    blank line between them.
+
+[#22]: https://github.com/dahlia/hongdown/issues/22
+
 
 Version 0.4.3
 -------------

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,33 +8,35 @@ To be released.
 
  -  Added MDX support.  MDX documents embed JavaScript and JSX that comrak (the
     underlying CommonMark parser) does not understand, so Hongdown used to
-    mangle them — turning straight quotes into curly quotes, backslash-escaping
+    mangle them—turning straight quotes into curly quotes, backslash-escaping
     Markdown punctuation, and collapsing indentation.  When MDX mode is
     enabled, Hongdown now detects those constructs and preserves them verbatim
-    while still formatting the surrounding Markdown prose.  [[#22]]
+    while still formatting the surrounding Markdown prose.
 
     Within Markdown prose, the protected constructs are ESM `import`/`export`
     statements, JSX elements and fragments, and `{…}` expressions (including JSX
     comments like `{/* … */}`).  The embedded JavaScript/JSX is preserved as-is,
     not reformatted; constructs that the underlying parser already handles
-    correctly — such as a valid inline-HTML JSX tag or a `{#id}` heading anchor
-    — are left to it.
+    correctly—such as a valid inline-HTML JSX tag or a `{#id}` heading
+    anchor—are left to it.
 
     MDX mode is enabled automatically for files with the *.mdx* extension, which
     are now also discovered when a directory is passed on the command line.  It
     can be turned on explicitly for stdin or *.md* input with the `--mdx`
     command-line flag or the `mdx` option in *.hongdown.toml* (Rust API:
     `Options.mdx`, type `bool`; WASM/JavaScript: `mdx`, type `boolean`).  All
-    default to off, so non-MDX documents are unaffected.
+    default to off, so non-MDX documents are unaffected.  [[#22], [#23]]
 
  -  Fixed a bug where a document whose only content was one or more HTML blocks
     (for example a single HTML comment) gained two spurious leading blank lines.
+    [[#23]]
 
  -  Fixed a bug where two consecutive trailing HTML blocks that were separated
     by a blank line in the source were emitted on adjacent lines, dropping the
-    blank line between them.
+    blank line between them.  [[#23]]
 
 [#22]: https://github.com/dahlia/hongdown/issues/22
+[#23]: https://github.com/dahlia/hongdown/pull/23
 
 
 Version 0.4.3

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ hongdown --line-width 100 input.md
 
 # Disable word wrapping entirely
 hongdown --no-line-width input.md
+
+# Enable MDX mode for non-.mdx input (.mdx files enable it automatically)
+hongdown --mdx input.md
 ~~~~
 
 ### HTML comment directives
@@ -214,6 +217,7 @@ git_aware = true          # Respect .gitignore and skip .git directory (default:
 # Formatting options
 line_width = 80           # Maximum line width (min: 8, default: 80); set to false to disable wrapping
 math = true               # Preserve TeX math ($…$ and $$…$$) verbatim (default: true)
+mdx = false               # MDX mode: preserve embedded JS/JSX verbatim (default: false)
 
 [heading]
 setext_h1 = true          # Use === underline for h1 (default: true)
@@ -463,6 +467,49 @@ $$
 x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}
 $$
 ~~~~
+
+### MDX
+
+MDX documents mix Markdown with JavaScript and JSX.  Because the underlying
+CommonMark parser does not understand those constructs, formatting an MDX
+document normally corrupts the embedded code.  *MDX mode* (“first, do no harm”)
+detects the JS/JSX constructs and passes them through verbatim, while the
+surrounding Markdown prose is still formatted.
+
+Within paragraph text, the constructs Hongdown would otherwise corrupt are
+preserved verbatim — never escaped or punctuation-transformed:
+
+ -  ESM `import`/`export` statements, JSX elements and fragments (`<Tabs …>`,
+    `<Chart … />`, `<>…</>`), and `{…}` expressions (including `{/* … */}`
+    comments)
+ -  The embedded JavaScript/JSX is preserved, not reformatted
+ -  Files with the *.mdx* extension enable MDX mode automatically; for stdin or
+    *.md* input, enable it with `--mdx` or `mdx = true` in *.hongdown.toml*
+
+~~~~ mdx
+import { Chart } from "./chart.js";
+
+export const meta = { author: "Hong Minhee" };
+
+<PackageManagerTabs
+  command={{ npm: "npm add @scope/pkg" }}
+/>
+
+A paragraph of prose is still wrapped and punctuation-transformed, while the
+JSX and imports above are left exactly as written.
+~~~~
+
+A JSX tag that is already valid inline HTML (for example a single `{value}`
+attribute) is left to the underlying parser, which keeps the tag while still
+formatting the element's Markdown children; only tags that break the HTML
+grammar (a `{{…}}` attribute, embedded quotes or spaces, or a multi-line opener)
+are protected as a whole.
+
+Some constructs are intentionally left unprotected: anything inside a heading
+(an explicit `{#id}` anchor stays a heading anchor), braces inside inline code
+(`` `{x}` ``), math (`$\frac{1}{2}$`), or link/image syntax, an expression
+containing a regex literal whose context is ambiguous (a `/` immediately after
+`}`), and an ESM object whose body contains a blank line.
 
 ### Links
 

--- a/STYLE.md
+++ b/STYLE.md
@@ -677,3 +677,60 @@ The HTML specification defines this behavior.
 
 *[HTML]: HyperText Markup Language
 ~~~~
+
+
+MDX
+---
+
+MDX documents interleave Markdown with JavaScript and JSX.  Those constructs are
+not part of CommonMark, so formatting them as ordinary Markdown corrupts the
+embedded code.  When MDX mode is enabled, the guiding principle is “first, do no
+harm”: detect the JavaScript/JSX constructs and preserve them verbatim, while
+still formatting the surrounding Markdown prose.
+
+MDX mode is off by default.  It is enabled automatically for files with the
+*.mdx* extension, and can be enabled explicitly for other input.
+
+Protection applies to constructs that appear in paragraph text and that Hongdown
+would otherwise corrupt.  Constructs inside headings are left to the heading
+formatter (an explicit `{#id}` anchor stays a heading anchor).
+
+### Preserve embedded JavaScript and JSX
+
+The following constructs are preserved exactly as written — never wrapped,
+escaped, or punctuation-transformed:
+
+ -  ESM `import` and `export` statements
+ -  JSX elements (`<Tabs …>…</Tabs>`, `<Chart … />`) and fragments (`<>…</>`)
+ -  `{…}` expressions, including JSX comments (`{/* … */}`)
+
+~~~~ mdx
+import { Chart } from "./chart.js";
+
+export const meta = { author: "Hong Minhee" };
+
+<Chart data={{ title: "Sales" }} />
+
+The total is {formatCurrency("USD", total)} for the year.
+~~~~
+
+The embedded JavaScript and JSX is preserved, not reformatted; only the
+surrounding Markdown is formatted.  A JSX element whose opening tag is valid
+inline HTML (for example a single `{value}` attribute) keeps its tag while its
+Markdown children are still formatted; an element whose opening tag breaks the
+HTML grammar (a `{{…}}` attribute, embedded quotes or spaces, or a multi-line
+opener) is preserved as a whole.
+
+### Leave ambiguous and parser-owned constructs alone
+
+To avoid corrupting code, some constructs are deliberately left to the
+underlying parser instead of being protected:
+
+ -  Braces inside inline code (`` `{x}` ``), math (`$\frac{1}{2}$`), and
+    link/image syntax are not treated as expressions
+ -  Constructs inside a heading are left to the heading formatter (an explicit
+    `{#id}` anchor stays a heading anchor, not an expression)
+ -  Where distinguishing a regex literal from division would require a full
+    JavaScript parser (a `/` immediately after `}`), or where an ESM object's
+    body contains a blank line, the construct is left unprotected rather than
+    risk mis-protecting it

--- a/packages/wasm/src/types.ts
+++ b/packages/wasm/src/types.ts
@@ -35,6 +35,15 @@ export interface FormatOptions {
   math?: boolean;
 
   /**
+   * Enable MDX mode. When enabled, embedded JavaScript/JSX — ESM
+   * `import`/`export` statements, JSX elements and fragments, and `{…}`
+   * expressions — is preserved verbatim instead of being mangled, while the
+   * surrounding Markdown prose is still formatted.
+   * @default false
+   */
+  mdx?: boolean;
+
+  /**
    * Use setext-style (underlined) for h1 headings.
    * @default true
    */

--- a/src/config.rs
+++ b/src/config.rs
@@ -23,6 +23,11 @@ fn default_math() -> bool {
     true
 }
 
+/// Default value for `mdx` (false).
+fn default_mdx() -> bool {
+    false
+}
+
 /// Default value for `line_width`: `Some(LineWidth::default())`.
 fn default_some_line_width() -> Option<LineWidth> {
     Some(LineWidth::default())
@@ -121,6 +126,11 @@ pub struct Config {
     #[serde(default = "default_math")]
     pub math: bool,
 
+    /// Enable MDX mode: preserve embedded JavaScript/JSX verbatim (default:
+    /// false).  The CLI also enables this automatically for *.mdx* files.
+    #[serde(default = "default_mdx")]
+    pub mdx: bool,
+
     /// Heading formatting options.
     pub heading: HeadingConfig,
 
@@ -149,6 +159,7 @@ impl Default for Config {
             exclude: Vec::new(),
             git_aware: true,
             math: true,
+            mdx: false,
             heading: HeadingConfig::default(),
             unordered_list: UnorderedListConfig::default(),
             ordered_list: OrderedListConfig::default(),
@@ -187,6 +198,9 @@ pub struct ConfigLayer {
 
     /// Recognize and preserve TeX/LaTeX math expressions.
     pub math: Option<bool>,
+
+    /// Enable MDX mode: preserve embedded JavaScript/JSX verbatim.
+    pub mdx: Option<bool>,
 
     /// Heading formatting options.
     pub heading: Option<HeadingConfig>,
@@ -245,6 +259,9 @@ impl ConfigLayer {
         }
         if let Some(math) = self.math {
             base.math = math;
+        }
+        if let Some(mdx) = self.mdx {
+            base.mdx = mdx;
         }
         if let Some(heading) = self.heading {
             base.heading = heading;
@@ -1287,6 +1304,7 @@ mod tests {
         assert_eq!(config.line_width.unwrap().get(), 80);
         assert!(config.git_aware);
         assert!(config.math);
+        assert!(!config.mdx);
         assert!(config.heading.setext_h1);
         assert!(config.heading.setext_h2);
         assert_eq!(
@@ -1355,6 +1373,37 @@ mod tests {
         };
         let merged = layer.merge_over(base);
         assert!(!merged.math);
+    }
+
+    #[test]
+    fn test_parse_mdx_enabled() {
+        let config = Config::from_toml("mdx = true").unwrap();
+        assert!(config.mdx);
+    }
+
+    #[test]
+    fn test_mdx_defaults_to_false_when_unset() {
+        let config = Config::from_toml("line_width = 100").unwrap();
+        assert!(!config.mdx);
+    }
+
+    #[test]
+    fn test_merge_over_mdx_enabled() {
+        let layer = ConfigLayer::from_toml_str("mdx = true\n").unwrap();
+        let merged = layer.merge_over(Config::default());
+        assert!(merged.mdx);
+    }
+
+    #[test]
+    fn test_merge_over_preserves_mdx_when_unset() {
+        // A layer that does not mention `mdx` must not reset it.
+        let layer = ConfigLayer::from_toml_str("line_width = 72\n").unwrap();
+        let base = Config {
+            mdx: true,
+            ..Config::default()
+        };
+        let merged = layer.merge_over(base);
+        assert!(merged.mdx);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -263,12 +263,12 @@ pub fn format(input: &str, options: &Options) -> Result<String, FormatError> {
     comrak_options.extension.math_dollars = options.math;
 
     if options.mdx
-        && let Some((protected, map)) = mdx::protect(input, &comrak_options)
+        && let Some(protection) = mdx::protect(input, &comrak_options)
     {
         let arena = Arena::new();
-        let root = parse_document(&arena, &protected, &comrak_options);
-        let output = serializer::serialize_with_source(root, options, Some(&protected));
-        return Ok(mdx::restore(&output, &map));
+        let root = parse_document(&arena, &protection.source, &comrak_options);
+        let output = serializer::serialize_with_source(root, options, Some(&protection.source));
+        return Ok(protection.restore(&output));
     }
 
     let arena = Arena::new();
@@ -318,14 +318,19 @@ pub fn format_with_warnings(input: &str, options: &Options) -> Result<FormatResu
     comrak_options.extension.math_dollars = options.math;
 
     if options.mdx
-        && let Some((protected, map)) = mdx::protect(input, &comrak_options)
+        && let Some(protection) = mdx::protect(input, &comrak_options)
     {
         let arena = Arena::new();
-        let root = parse_document(&arena, &protected, &comrak_options);
-        let result =
-            serializer::serialize_with_source_and_warnings(root, options, Some(&protected));
+        let root = parse_document(&arena, &protection.source, &comrak_options);
+        let mut result =
+            serializer::serialize_with_source_and_warnings(root, options, Some(&protection.source));
+        // Warning line numbers refer to the protected source; map them back to
+        // the original so multi-line constructs do not shift them.
+        for warning in &mut result.warnings {
+            warning.line = protection.original_line(warning.line);
+        }
         return Ok(FormatResult {
-            output: mdx::restore(&result.output, &map),
+            output: protection.restore(&result.output),
             warnings: result.warnings,
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,7 @@
 use std::collections::HashMap;
 
 pub mod config;
+mod mdx;
 mod serializer;
 
 #[cfg(feature = "wasm")]
@@ -51,6 +52,21 @@ pub struct Options {
     /// `$`, a shell prompt like `$ cmd`, or a price like `$5` is not treated as
     /// math.  Set to `false` to treat every `$` as literal text.
     pub math: bool,
+
+    /// Enable MDX mode. Default: false.
+    ///
+    /// MDX documents embed JavaScript/JSX that comrak (a plain CommonMark+GFM
+    /// parser) does not understand: ESM `import`/`export` statements, JSX
+    /// elements and fragments, and `{…}` expressions.  Without MDX mode these
+    /// constructs are parsed as ordinary prose and then mangled by punctuation
+    /// transforms and Markdown escaping.
+    ///
+    /// When enabled, Hongdown detects those constructs and passes them through
+    /// verbatim — "first, do no harm" — while still formatting the surrounding
+    /// Markdown prose.  The embedded JavaScript/JSX itself is preserved as-is,
+    /// not reformatted.  The CLI enables this automatically for files with the
+    /// *.mdx* extension.
+    pub mdx: bool,
 
     /// Use setext-style (underlined) for h1 headings. Default: true.
     pub setext_h1: bool,
@@ -177,6 +193,7 @@ impl Default for Options {
         Self {
             line_width: Some(LineWidth::default()),
             math: true,
+            mdx: false,
             setext_h1: true,
             setext_h2: true,
             heading_sentence_case: false,
@@ -236,7 +253,6 @@ pub fn format(input: &str, options: &Options) -> Result<String, FormatError> {
         return Ok(String::new());
     }
 
-    let arena = Arena::new();
     let mut comrak_options = ComrakOptions::default();
     comrak_options.extension.front_matter_delimiter = Some("---".to_string());
     comrak_options.extension.table = true;
@@ -246,6 +262,16 @@ pub fn format(input: &str, options: &Options) -> Result<String, FormatError> {
     comrak_options.extension.tasklist = true;
     comrak_options.extension.math_dollars = options.math;
 
+    if options.mdx
+        && let Some((protected, map)) = mdx::protect(input, &comrak_options)
+    {
+        let arena = Arena::new();
+        let root = parse_document(&arena, &protected, &comrak_options);
+        let output = serializer::serialize_with_source(root, options, Some(&protected));
+        return Ok(mdx::restore(&output, &map));
+    }
+
+    let arena = Arena::new();
     let root = parse_document(&arena, input, &comrak_options);
     let output = serializer::serialize_with_source(root, options, Some(input));
 
@@ -282,7 +308,6 @@ pub fn format_with_warnings(input: &str, options: &Options) -> Result<FormatResu
         });
     }
 
-    let arena = Arena::new();
     let mut comrak_options = ComrakOptions::default();
     comrak_options.extension.front_matter_delimiter = Some("---".to_string());
     comrak_options.extension.table = true;
@@ -292,6 +317,20 @@ pub fn format_with_warnings(input: &str, options: &Options) -> Result<FormatResu
     comrak_options.extension.tasklist = true;
     comrak_options.extension.math_dollars = options.math;
 
+    if options.mdx
+        && let Some((protected, map)) = mdx::protect(input, &comrak_options)
+    {
+        let arena = Arena::new();
+        let root = parse_document(&arena, &protected, &comrak_options);
+        let result =
+            serializer::serialize_with_source_and_warnings(root, options, Some(&protected));
+        return Ok(FormatResult {
+            output: mdx::restore(&result.output, &map),
+            warnings: result.warnings,
+        });
+    }
+
+    let arena = Arena::new();
     let root = parse_document(&arena, input, &comrak_options);
     let result = serializer::serialize_with_source_and_warnings(root, options, Some(input));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,6 +74,7 @@ fn main() -> ExitCode {
     let options = Options {
         line_width,
         math: config.math,
+        mdx: false,
         setext_h1: config.heading.setext_h1,
         setext_h2: config.heading.setext_h2,
         heading_sentence_case: config.heading.sentence_case,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 //! Hongdown CLI - A Markdown formatter for Hong Minhee's style conventions.
 
+use std::borrow::Cow;
 use std::fs;
 use std::io::{self, Read};
 use std::path::{Path, PathBuf};
@@ -46,6 +47,11 @@ struct Args {
     #[arg(long, conflicts_with = "line_width")]
     no_line_width: bool,
 
+    /// Enable MDX mode for all inputs (preserve embedded JavaScript/JSX).
+    /// Files with the *.mdx* extension enable this automatically.
+    #[arg(long)]
+    mdx: bool,
+
     /// Path to configuration file.
     #[arg(long, value_name = "FILE")]
     config: Option<PathBuf>,
@@ -74,7 +80,7 @@ fn main() -> ExitCode {
     let options = Options {
         line_width,
         math: config.math,
-        mdx: false,
+        mdx: config.mdx || args.mdx,
         setext_h1: config.heading.setext_h1,
         setext_h2: config.heading.setext_h2,
         heading_sentence_case: config.heading.sentence_case,
@@ -223,7 +229,8 @@ fn process_files_parallel(
             }
         };
 
-        match format_with_warnings(&input, options) {
+        let file_options = options_for_file(options, file);
+        match format_with_warnings(&input, &file_options) {
             Ok(result) => {
                 // Print warnings to stderr
                 for warning in &result.warnings {
@@ -277,7 +284,8 @@ fn process_files_sequential(files: &[PathBuf], options: &Options) -> ExitCode {
             }
         };
 
-        match format_with_warnings(&input, options) {
+        let file_options = options_for_file(options, file);
+        match format_with_warnings(&input, &file_options) {
             Ok(result) => {
                 // Print warnings to stderr
                 for warning in &result.warnings {
@@ -311,7 +319,8 @@ fn process_files_diff(files: &[PathBuf], options: &Options) -> ExitCode {
             }
         };
 
-        match format_with_warnings(&input, options) {
+        let file_options = options_for_file(options, file);
+        match format_with_warnings(&input, &file_options) {
             Ok(result) => {
                 // Print warnings to stderr
                 for warning in &result.warnings {
@@ -377,7 +386,8 @@ fn expand_paths(paths: &[PathBuf]) -> Vec<PathBuf> {
     result
 }
 
-/// Recursively collect all Markdown files (`.md` and `.markdown`) from a directory.
+/// Recursively collect all Markdown files (`.md`, `.markdown`, and `.mdx`) from a
+/// directory.
 fn collect_md_files(dir: &Path) -> Vec<PathBuf> {
     let mut files = Vec::new();
     for entry in WalkDir::new(dir).follow_links(true) {
@@ -385,7 +395,9 @@ fn collect_md_files(dir: &Path) -> Vec<PathBuf> {
         let path = entry.path();
         if path.is_file() {
             let is_markdown = path.extension().is_some_and(|ext| {
-                ext.eq_ignore_ascii_case("md") || ext.eq_ignore_ascii_case("markdown")
+                ext.eq_ignore_ascii_case("md")
+                    || ext.eq_ignore_ascii_case("markdown")
+                    || ext.eq_ignore_ascii_case("mdx")
             });
             if is_markdown {
                 files.push(path.to_path_buf());
@@ -394,6 +406,25 @@ fn collect_md_files(dir: &Path) -> Vec<PathBuf> {
     }
     files.sort();
     files
+}
+
+/// Whether `path` has the `.mdx` extension (case-insensitive).
+fn has_mdx_extension(path: &Path) -> bool {
+    path.extension()
+        .is_some_and(|ext| ext.eq_ignore_ascii_case("mdx"))
+}
+
+/// Build the formatting options for a specific file, enabling MDX mode
+/// automatically for `.mdx` files.  Borrows the base options unless a per-file
+/// override is needed.
+fn options_for_file<'a>(base: &'a Options, path: &Path) -> Cow<'a, Options> {
+    if !base.mdx && has_mdx_extension(path) {
+        let mut options = base.clone();
+        options.mdx = true;
+        Cow::Owned(options)
+    } else {
+        Cow::Borrowed(base)
+    }
 }
 
 /// Load configuration from file or use defaults.

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -550,6 +550,12 @@ fn is_tag_name_byte(byte: u8) -> bool {
     byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_' | b'$')
 }
 
+/// Whether `byte` can start a JSX tag or component name.  Like a JavaScript
+/// identifier, a name may begin with a letter, `_`, or `$`.
+fn is_tag_name_start(byte: u8) -> bool {
+    byte.is_ascii_alphabetic() || matches!(byte, b'_' | b'$')
+}
+
 /// A parsed JSX opening tag (or fragment opener `<>`).
 struct OpenTag<'a> {
     /// Byte offset just past the tag's closing `>` or `/>`.
@@ -596,8 +602,8 @@ fn scan_open_tag(span: &str, start: usize) -> OpenTagScan<'_> {
             multiline: false,
         });
     }
-    // A tag name must begin with a letter.
-    if !bytes.get(start + 1).is_some_and(u8::is_ascii_alphabetic) {
+    // A tag name must begin with a letter, `_`, or `$`.
+    if !bytes.get(start + 1).is_some_and(|&b| is_tag_name_start(b)) {
         return OpenTagScan::NoMatch;
     }
     let name_start = start + 1;
@@ -917,7 +923,7 @@ fn scan_jsx(span: &str, start: usize) -> JsxScan {
     // Must be able to begin a JSX construct: `<>` or `<` + tag name.
     match bytes.get(start + 1) {
         Some(b'>') => {}
-        Some(&byte) if byte.is_ascii_alphabetic() => {}
+        Some(&byte) if is_tag_name_start(byte) => {}
         _ => return JsxScan::NoMatch,
     }
 
@@ -959,9 +965,7 @@ fn scan_jsx(span: &str, start: usize) -> JsxScan {
                 }
             }
             b'<' if matches!(bytes.get(index + 1), Some(b'>'))
-                || bytes
-                    .get(index + 1)
-                    .is_some_and(|b| b.is_ascii_alphabetic()) =>
+                || bytes.get(index + 1).is_some_and(|&b| is_tag_name_start(b)) =>
             {
                 match scan_open_tag(span, index) {
                     OpenTagScan::Parsed(tag) => {
@@ -1229,6 +1233,19 @@ mod tests {
     fn scan_jsx_self_closing_with_expression_attr() {
         let span = "<Chart data={data} />";
         assert_eq!(jsx_end(span), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_jsx_tag_name_starting_with_underscore_or_dollar() {
+        // JSX component names may begin with `_` or `$`, like JS identifiers.
+        let underscore = "<_Component data={x} />";
+        assert_eq!(jsx_end(underscore), Some(underscore.len()));
+        let dollar = "<$El data={x} />";
+        assert_eq!(jsx_end(dollar), Some(dollar.len()));
+        // A container whose `_`-named opener carries an expression attribute is
+        // protected, and its `</_Box>` close is matched.
+        let container = "<_Box id={i}>text</_Box>";
+        assert_eq!(jsx_end(container), Some(container.len()));
     }
 
     #[test]

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -495,8 +495,14 @@ fn scan_esm(span: &str, start: usize) -> Option<usize> {
                     // Ambiguous regex-or-division after `}`; do not guess.
                     return None;
                 } else if allows_regex(prev, prev_word) {
-                    index = skip_regex(span, index).unwrap_or(index + 1);
-                    prev = Some(VALUE);
+                    if let Some(after) = skip_regex(span, index) {
+                        index = after;
+                        prev = Some(VALUE); // a regex is a value: a following `/` is division
+                    } else {
+                        // Not a valid regex after all; treat the `/` as division.
+                        index += 1;
+                        prev = Some(b'/');
+                    }
                     prev_word = None;
                 } else {
                     index += 1;

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -408,7 +408,12 @@ fn scan_esm(span: &str, start: usize) -> Option<usize> {
     if !is_import && !rest.starts_with("export") {
         return None;
     }
-    let after = start + "import".len();
+    let after = start
+        + if is_import {
+            "import".len()
+        } else {
+            "export".len()
+        };
     // The character after the keyword must be plausible ESM, not the tail of an
     // identifier ("important", "exports") or sentence punctuation ("import.").
     match bytes.get(after) {

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -371,17 +371,6 @@ fn read_word(source: &str, pos: usize) -> &str {
     &source[pos..end]
 }
 
-/// Whether `word` occurs at byte offset `at` as a standalone token (bounded by
-/// non-identifier bytes on both sides).
-fn is_word_at(bytes: &[u8], at: usize, word: &[u8]) -> bool {
-    if at + word.len() > bytes.len() || &bytes[at..at + word.len()] != word {
-        return false;
-    }
-    let before_ok = at == 0 || !is_ident_byte(bytes[at - 1]);
-    let after_ok = at + word.len() >= bytes.len() || !is_ident_byte(bytes[at + word.len()]);
-    before_ok && after_ok
-}
-
 /// If an ESM `import`/`export` statement starts at `start` within `span`, return
 /// the byte offset just past its end (before the terminating newline).
 ///
@@ -450,41 +439,28 @@ fn scan_esm(span: &str, start: usize) -> Option<usize> {
         }
     }
 
+    const VALUE: u8 = b'a';
     let mut index = after;
     let mut depth: i32 = 0;
     let mut saw_from = false;
+    // The most recent significant token, used (as in `skip_braces`) to tell a
+    // regex literal from a division operator.
+    let mut prev: Option<u8> = None;
+    let mut prev_word: Option<&str> = None;
     while index < span.len() {
-        match bytes[index] {
-            b'"' | b'\'' | b'`' => {
-                index = skip_string(span, index)?;
-            }
-            b'/' => {
-                if let Some(after) = skip_comment(span, index) {
-                    index = after;
-                } else {
-                    index += 1;
-                }
-            }
-            b'{' | b'(' | b'[' => {
-                depth += 1;
+        let byte = bytes[index];
+        if is_ident_byte(byte) {
+            let after_member_access = prev == Some(b'.');
+            let word_start = index;
+            while index < span.len() && is_ident_byte(bytes[index]) {
                 index += 1;
             }
-            b'}' | b')' | b']' => {
-                depth -= 1;
-                index += 1;
-            }
-            b'\n' => {
-                if depth <= 0 {
-                    return finish_esm(index, needs_from, saw_from);
-                }
-                index += 1;
-            }
-            b'f' if needs_from && !saw_from && is_word_at(bytes, index, b"from") => {
-                // A genuine `from` clause is followed by the module string
-                // specifier, e.g. `from "./x"`.  Requiring the string rejects
-                // ordinary prose such as "import these ideas from elsewhere."
-                // The specifier may sit on the next line, so skip newlines too.
-                let mut probe = index + 4;
+            let word = &span[word_start..index];
+            // A genuine `from` clause is followed by the module string specifier,
+            // e.g. `from "./x"` (which may sit on the next line).  Requiring the
+            // string rejects prose such as "import these ideas from elsewhere."
+            if needs_from && !saw_from && !after_member_access && word == "from" {
+                let mut probe = index;
                 while probe < span.len() && matches!(bytes[probe], b' ' | b'\t' | b'\n' | b'\r') {
                     probe += 1;
                 }
@@ -493,11 +469,65 @@ fn scan_esm(span: &str, start: usize) -> Option<usize> {
                     // Jump to the specifier so an intervening newline is not
                     // mistaken for the end of the statement.
                     index = probe;
-                } else {
-                    index += 4;
+                    prev = Some(VALUE);
+                    prev_word = None;
+                    continue;
                 }
             }
-            _ => index += char_len(bytes[index]),
+            prev = Some(VALUE);
+            prev_word = if after_member_access {
+                None
+            } else {
+                Some(word)
+            };
+            continue;
+        }
+        match byte {
+            b'"' | b'\'' | b'`' => {
+                index = skip_string(span, index)?;
+                prev = Some(VALUE);
+                prev_word = None;
+            }
+            b'/' => {
+                if let Some(after) = skip_comment(span, index) {
+                    index = after; // comments do not change the preceding token
+                } else if prev == Some(b'}') {
+                    // Ambiguous regex-or-division after `}`; do not guess.
+                    return None;
+                } else if allows_regex(prev, prev_word) {
+                    index = skip_regex(span, index).unwrap_or(index + 1);
+                    prev = Some(VALUE);
+                    prev_word = None;
+                } else {
+                    index += 1;
+                    prev = Some(b'/');
+                    prev_word = None;
+                }
+            }
+            b'{' | b'(' | b'[' => {
+                depth += 1;
+                index += 1;
+                prev = Some(byte);
+                prev_word = None;
+            }
+            b'}' | b')' | b']' => {
+                depth -= 1;
+                index += 1;
+                prev = Some(byte);
+                prev_word = None;
+            }
+            b'\n' => {
+                if depth <= 0 {
+                    return finish_esm(index, needs_from, saw_from);
+                }
+                index += 1; // inside brackets: leave the preceding token unchanged
+            }
+            b' ' | b'\t' | b'\r' => index += 1, // whitespace: leave prev unchanged
+            other => {
+                index += char_len(other);
+                prev = Some(other);
+                prev_word = None;
+            }
         }
     }
     // Reached the end of the span: complete only if brackets balanced out.
@@ -1031,6 +1061,10 @@ fn scan_expression(span: &str, start: usize) -> ExprScan {
 /// Skip a string literal that starts at `start` (a `"`, `'`, or `` ` `` quote).
 /// Returns the byte offset just past the closing quote, or `None` if the string
 /// is unterminated.
+///
+/// In a template literal (`` ` ``), a `${…}` interpolation is skipped as a
+/// balanced expression so that backticks or braces inside it (including nested
+/// template literals) do not terminate the string early.
 fn skip_string(span: &str, start: usize) -> Option<usize> {
     let bytes = span.as_bytes();
     let quote = bytes[start];
@@ -1042,6 +1076,13 @@ fn skip_string(span: &str, start: usize) -> Option<usize> {
                 index += 1;
                 if index < span.len() {
                     index += char_len(bytes[index]);
+                }
+            }
+            b'$' if quote == b'`' && bytes.get(index + 1) == Some(&b'{') => {
+                // Template literal interpolation `${ … }`.
+                match skip_braces(span, index + 1) {
+                    BraceScan::Closed(after) => index = after,
+                    _ => return None,
                 }
             }
             byte if byte == quote => return Some(index + 1),
@@ -1145,6 +1186,22 @@ mod tests {
     fn scan_esm_string_with_angle_and_brace() {
         // `>` and `{` inside the string must not derail the scan.
         let span = "import x from \"a > b { c\";";
+        assert_eq!(scan_esm(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_esm_skips_regex_with_brace() {
+        // A `}` inside a regex character class must not be counted as a brace,
+        // which would otherwise end a multi-line object early.
+        let span = "export const config = {\n  re: /[}]/,\n  x: 1,\n};";
+        assert_eq!(scan_esm(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_esm_division_not_regex() {
+        // `/` after a value is division, not a regex; the statement still ends
+        // at its newline.
+        let span = "export const ratio = a / b;";
         assert_eq!(scan_esm(span, 0), Some(span.len()));
     }
 
@@ -1533,6 +1590,24 @@ mod tests {
     fn skip_string_handles_escapes() {
         let span = r#""a\"b""#; // "a\"b"
         assert_eq!(skip_string(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn skip_string_template_literal_with_nested_interpolation() {
+        // A `${…}` interpolation, including a nested template literal inside it,
+        // must not end the outer template early.
+        let span = "`a ${`b`} c`";
+        assert_eq!(skip_string(span, 0), Some(span.len()));
+        let nested = "`x ${`y ${z} w`} v`";
+        assert_eq!(skip_string(nested, 0), Some(nested.len()));
+    }
+
+    #[test]
+    fn scan_expression_template_literal_with_nested_braces() {
+        // The expression brace count stays balanced across a template literal
+        // whose interpolation contains its own braces.
+        let span = "{`${`a`} ${ {k: 1} }`}";
+        assert_eq!(expr_end(span), Some(span.len()));
     }
 
     #[test]

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -479,14 +479,19 @@ fn scan_esm(span: &str, start: usize) -> Option<usize> {
                 // A genuine `from` clause is followed by the module string
                 // specifier, e.g. `from "./x"`.  Requiring the string rejects
                 // ordinary prose such as "import these ideas from elsewhere."
+                // The specifier may sit on the next line, so skip newlines too.
                 let mut probe = index + 4;
-                while probe < span.len() && matches!(bytes[probe], b' ' | b'\t') {
+                while probe < span.len() && matches!(bytes[probe], b' ' | b'\t' | b'\n' | b'\r') {
                     probe += 1;
                 }
                 if matches!(bytes.get(probe), Some(b'"' | b'\'' | b'`')) {
                     saw_from = true;
+                    // Jump to the specifier so an intervening newline is not
+                    // mistaken for the end of the statement.
+                    index = probe;
+                } else {
+                    index += 4;
                 }
-                index += 4;
             }
             _ => index += char_len(bytes[index]),
         }
@@ -1183,6 +1188,14 @@ mod tests {
     #[test]
     fn scan_esm_default_import_with_string_from() {
         let span = "import Chart from \"./chart.js\";";
+        assert_eq!(scan_esm(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_esm_from_clause_across_newline() {
+        // The module specifier may sit on the next line after `from`; the
+        // statement must continue across that newline.
+        let span = "import Chart from\n  \"./chart.js\";";
         assert_eq!(scan_esm(span, 0), Some(span.len()));
     }
 

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -449,8 +449,12 @@ fn scan_esm(span: &str, start: usize) -> Option<usize> {
             b'"' | b'\'' | b'`' => {
                 index = skip_string(span, index)?;
             }
-            b'/' if let Some(after) = skip_comment(span, index) => {
-                index = after;
+            b'/' => {
+                if let Some(after) = skip_comment(span, index) {
+                    index = after;
+                } else {
+                    index += 1;
+                }
             }
             b'{' | b'(' | b'[' => {
                 depth += 1;
@@ -735,26 +739,31 @@ fn skip_braces(span: &str, start: usize) -> BraceScan {
                 prev = Some(VALUE); // a string is a value: a following `/` is division
                 prev_word = None;
             }
-            b'/' if let Some(after) = skip_comment(span, index) => {
-                index = after; // comments do not change the preceding token
-            }
-            b'/' if prev == Some(b'}') => {
-                // A `/` right after `}` is genuinely ambiguous without a JS
-                // parser: regex after a block close, or division after an object
-                // literal.  Rather than guess (and risk miscounting a `}` inside
-                // a regex character class), give up and leave the whole
-                // expression to comrak.
-                return BraceScan::Ambiguous;
-            }
-            b'/' if allows_regex(prev, prev_word) => {
-                if let Some(after) = skip_regex(span, index) {
-                    index = after;
-                    prev = Some(VALUE); // a regex is a value: a following `/` is division
+            b'/' => {
+                if let Some(after) = skip_comment(span, index) {
+                    index = after; // comments do not change the preceding token
+                } else if prev == Some(b'}') {
+                    // A `/` right after `}` is genuinely ambiguous without a JS
+                    // parser: regex after a block close, or division after an
+                    // object literal.  Rather than guess (and risk miscounting a
+                    // `}` inside a regex character class), give up and leave the
+                    // whole expression to comrak.
+                    return BraceScan::Ambiguous;
+                } else if allows_regex(prev, prev_word) {
+                    if let Some(after) = skip_regex(span, index) {
+                        index = after;
+                        prev = Some(VALUE); // a regex is a value: a following `/` is division
+                    } else {
+                        index += 1;
+                        prev = Some(b'/');
+                    }
+                    prev_word = None;
                 } else {
+                    // Division.
                     index += 1;
                     prev = Some(b'/');
+                    prev_word = None;
                 }
-                prev_word = None;
             }
             b' ' | b'\t' | b'\n' | b'\r' => index += 1,
             other => {

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -15,11 +15,11 @@
 //! surrounding Markdown prose is formatted normally.  [`restore`] then swaps the
 //! placeholders back for their original text.
 //!
-//! The detection is AST-guided: only the source spans of `Paragraph` and
-//! `Heading` nodes are scanned.  Content inside fenced/indented code blocks,
-//! inline code spans, math, front matter, and HTML blocks never becomes
-//! paragraph text in comrak's AST, so it is naturally left untouched — we only
-//! ever touch what comrak would otherwise corrupt.
+//! The detection is AST-guided: only the source spans of `Paragraph` nodes are
+//! scanned.  Content inside fenced/indented code blocks, inline code spans,
+//! math, front matter, headings, and HTML blocks never becomes paragraph text
+//! in comrak's AST, so it is naturally left untouched — we only ever touch what
+//! comrak would otherwise corrupt.
 
 use comrak::nodes::{NodeValue, Sourcepos};
 use comrak::{Arena, Options as ComrakOptions, parse_document};
@@ -51,7 +51,11 @@ pub(crate) fn protect(
     for node in root.descendants() {
         let (is_target, sourcepos) = {
             let data = node.data.borrow();
-            let is_target = matches!(data.value, NodeValue::Paragraph | NodeValue::Heading(_));
+            // Only paragraphs are scanned.  Headings are skipped: their inline
+            // serialization (sentence case, width measurement, anchor handling)
+            // does not preserve placeholder comments, and skipping them also
+            // keeps explicit `{#anchor}` identifiers from being misdetected.
+            let is_target = matches!(data.value, NodeValue::Paragraph);
             (is_target, data.sourcepos)
         };
         if !is_target {
@@ -61,7 +65,41 @@ pub(crate) fn protect(
             continue;
         };
         let span = &source[start..end];
-        for (relative_start, relative_end) in find_constructs(span) {
+
+        // Some inline constructs are owned by comrak's own syntax and must not be
+        // scanned: code spans and math are emitted verbatim; links/images have
+        // their own `[…](…)` bracket/paren structure (a `{…}` in link text would
+        // otherwise be protected, desyncing it from its reference definition);
+        // and inline HTML tags (which comrak already preserves) can carry `{…}`
+        // inside a quoted attribute.  Collect their (span-local) ranges to skip.
+        let mut skips: Vec<(usize, usize)> = Vec::new();
+        for inner in node.descendants() {
+            let (is_owned, inner_sourcepos) = {
+                let data = inner.data.borrow();
+                let is_owned = matches!(
+                    data.value,
+                    NodeValue::Code(_)
+                        | NodeValue::Math(_)
+                        | NodeValue::Link(_)
+                        | NodeValue::Image(_)
+                        | NodeValue::HtmlInline(_)
+                );
+                (is_owned, data.sourcepos)
+            };
+            if !is_owned {
+                continue;
+            }
+            if let Some((inner_start, inner_end)) =
+                span_bytes(source, &line_starts, inner_sourcepos)
+                && inner_start >= start
+                && inner_end <= end
+            {
+                skips.push((inner_start - start, inner_end - start));
+            }
+        }
+        skips.sort_by_key(|&(skip_start, _)| skip_start);
+
+        for (relative_start, relative_end) in find_constructs(span, &skips) {
             ranges.push((start + relative_start, start + relative_end));
         }
     }
@@ -149,15 +187,25 @@ fn span_bytes(source: &str, line_starts: &[usize], sourcepos: Sourcepos) -> Opti
 /// is left unprotected (a documented limitation) rather than scanning into
 /// unrelated later content.
 ///
-/// Detects ESM `import`/`export` statements (recognized at line starts) and JSX
-/// elements/fragments (recognized anywhere).  `{…}` expressions are added
-/// incrementally.
-fn find_constructs(span: &str) -> Vec<(usize, usize)> {
+/// Detects ESM `import`/`export` statements (recognized at line starts), JSX
+/// elements/fragments, and `{…}` expressions (recognized anywhere).
+///
+/// `skips` lists span-local ranges of inline code spans and math that comrak
+/// already preserves verbatim; their contents are never scanned, so the
+/// `{`/`<`/`}` they contain cannot be mistaken for MDX constructs.  `skips` must
+/// be sorted by start offset.
+fn find_constructs(span: &str, skips: &[(usize, usize)]) -> Vec<(usize, usize)> {
     let bytes = span.as_bytes();
     let mut ranges = Vec::new();
     let mut index = 0;
     let mut at_line_start = true;
     while index < span.len() {
+        // Jump over inline code/math that comrak emits verbatim.
+        if let Some(skip_end) = skip_range_end(skips, index) {
+            index = skip_end;
+            at_line_start = bytes.get(index) == Some(&b'\n');
+            continue;
+        }
         if at_line_start {
             // CommonMark paragraphs allow up to three leading spaces.
             let mut scan = index;
@@ -174,13 +222,34 @@ fn find_constructs(span: &str) -> Vec<(usize, usize)> {
             }
         }
         // JSX elements and fragments can appear anywhere (flow or inline).
-        if bytes[index] == b'<'
-            && let Some(end) = scan_jsx(span, index)
-        {
-            ranges.push((index, end));
-            index = end;
-            at_line_start = bytes.get(index) == Some(&b'\n');
-            continue;
+        if bytes[index] == b'<' {
+            match scan_jsx(span, index) {
+                JsxScan::Matched(end) => {
+                    ranges.push((index, end));
+                    index = end;
+                    at_line_start = bytes.get(index) == Some(&b'\n');
+                    continue;
+                }
+                JsxScan::GiveUp => break,
+                JsxScan::NoMatch => {}
+            }
+        }
+        // Bare `{…}` expressions can appear anywhere (flow or inline).
+        if bytes[index] == b'{' {
+            match scan_expression(span, index) {
+                ExprScan::Matched(end) => {
+                    ranges.push((index, end));
+                    index = end;
+                    at_line_start = bytes.get(index) == Some(&b'\n');
+                    continue;
+                }
+                ExprScan::GiveUp => {
+                    // Leave the rest of this span to comrak so no nested `{…}` is
+                    // protected in isolation.
+                    break;
+                }
+                ExprScan::NoMatch => {}
+            }
         }
         if bytes[index] == b'\n' {
             at_line_start = true;
@@ -191,6 +260,20 @@ fn find_constructs(span: &str) -> Vec<(usize, usize)> {
         }
     }
     ranges
+}
+
+/// If `index` falls within one of the sorted, non-overlapping `skips` ranges,
+/// return that range's end offset.
+fn skip_range_end(skips: &[(usize, usize)], index: usize) -> Option<usize> {
+    for &(start, end) in skips {
+        if start > index {
+            break;
+        }
+        if index < end {
+            return Some(end);
+        }
+    }
+    None
 }
 
 /// Keywords that may follow `export` to form an export declaration.
@@ -408,15 +491,28 @@ struct OpenTag<'a> {
     multiline: bool,
 }
 
+/// Outcome of scanning a JSX opening tag.
+enum OpenTagScan<'a> {
+    /// A well-formed opening tag (or fragment opener).
+    Parsed(OpenTag<'a>),
+    /// A protect-worthy tag (it carries a `{…}` attribute or spans lines) that
+    /// could not be delimited; the caller should give up on the whole construct.
+    GiveUp,
+    /// Not a protect-worthy opening tag here.
+    NoMatch,
+}
+
 /// Parse a JSX opening tag (or fragment `<>`) starting at `start` (a `<`).
 /// String literals and `{…}` expression attributes are skipped so that
-/// `>`/`{`/`}` inside them do not terminate the tag.  Returns `None` if the tag
-/// is not well-formed within the span.
-fn scan_open_tag(span: &str, start: usize) -> Option<OpenTag<'_>> {
+/// `>`/`{`/`}` inside them do not terminate the tag.  Returns [`OpenTagScan`]:
+/// once the tag is seen to be protect-worthy (a `{…}` attribute or a newline)
+/// but cannot be completed, the result is `GiveUp` rather than `NoMatch`, so the
+/// caller never partially scans inside it.
+fn scan_open_tag(span: &str, start: usize) -> OpenTagScan<'_> {
     let bytes = span.as_bytes();
     // Fragment opener `<>`.
     if bytes.get(start + 1) == Some(&b'>') {
-        return Some(OpenTag {
+        return OpenTagScan::Parsed(OpenTag {
             end: start + 2,
             name: "",
             self_closing: false,
@@ -427,7 +523,7 @@ fn scan_open_tag(span: &str, start: usize) -> Option<OpenTag<'_>> {
     }
     // A tag name must begin with a letter.
     if !bytes.get(start + 1).is_some_and(u8::is_ascii_alphabetic) {
-        return None;
+        return OpenTagScan::NoMatch;
     }
     let name_start = start + 1;
     let mut index = name_start;
@@ -438,10 +534,18 @@ fn scan_open_tag(span: &str, start: usize) -> Option<OpenTag<'_>> {
 
     let mut has_expression = false;
     let mut multiline = false;
+    // Whether failure to complete should give up (protect-worthy) or no-match.
+    let give_up_on_failure = |has_expression: bool, multiline: bool| {
+        if has_expression || multiline {
+            OpenTagScan::GiveUp
+        } else {
+            OpenTagScan::NoMatch
+        }
+    };
     while index < span.len() {
         match bytes[index] {
             b'>' => {
-                return Some(OpenTag {
+                return OpenTagScan::Parsed(OpenTag {
                     end: index + 1,
                     name,
                     self_closing: false,
@@ -451,7 +555,7 @@ fn scan_open_tag(span: &str, start: usize) -> Option<OpenTag<'_>> {
                 });
             }
             b'/' if bytes.get(index + 1) == Some(&b'>') => {
-                return Some(OpenTag {
+                return OpenTagScan::Parsed(OpenTag {
                     end: index + 2,
                     name,
                     self_closing: true,
@@ -462,11 +566,15 @@ fn scan_open_tag(span: &str, start: usize) -> Option<OpenTag<'_>> {
             }
             b'{' => {
                 has_expression = true;
-                index = skip_braces(span, index)?;
+                match skip_braces(span, index) {
+                    BraceScan::Closed(after) => index = after,
+                    _ => return OpenTagScan::GiveUp,
+                }
             }
-            b'"' | b'\'' | b'`' => {
-                index = skip_string(span, index)?;
-            }
+            b'"' | b'\'' | b'`' => match skip_string(span, index) {
+                Some(after) => index = after,
+                None => return give_up_on_failure(has_expression, multiline),
+            },
             b'\n' => {
                 multiline = true;
                 index += 1;
@@ -474,7 +582,7 @@ fn scan_open_tag(span: &str, start: usize) -> Option<OpenTag<'_>> {
             byte => index += char_len(byte),
         }
     }
-    None
+    give_up_on_failure(has_expression, multiline)
 }
 
 /// Read a JSX closing tag `</name>` (or fragment close `</>`) starting at `start`
@@ -497,61 +605,240 @@ fn read_close_tag(span: &str, start: usize) -> Option<(&str, usize)> {
     Some((name, index + 1))
 }
 
-/// Skip a balanced `{…}` expression starting at `start` (a `{`).  Returns the
-/// byte offset just past the matching `}`.  String literals and comments inside
-/// are skipped so their braces do not affect nesting.  Returns `None` if the
-/// braces never balance within the span.
-fn skip_braces(span: &str, start: usize) -> Option<usize> {
+/// Outcome of scanning a `{…}` region.
+enum BraceScan {
+    /// The braces balanced; the value is the byte offset just past the `}`.
+    Closed(usize),
+    /// A `/` after `}` made regex-vs-division undecidable; give up on the region.
+    Ambiguous,
+    /// The braces never balanced within the span.
+    Unbalanced,
+}
+
+/// Skip a balanced `{…}` expression starting at `start` (a `{`).  String
+/// literals, comments, and regex literals inside are skipped so their braces do
+/// not affect nesting.  Returns [`BraceScan::Closed`] with the byte offset just
+/// past the matching `}`, [`BraceScan::Ambiguous`] when a `/` after `}` cannot be
+/// classified, or [`BraceScan::Unbalanced`] when the braces never balance.
+fn skip_braces(span: &str, start: usize) -> BraceScan {
     let bytes = span.as_bytes();
     let mut depth = 0i32;
     let mut index = start;
+    // The most recent significant token, used to tell a regex literal from a
+    // division operator: `prev` is the last significant byte (`VALUE` stands for
+    // identifiers/numbers/strings/regexes), and `prev_word` is the last
+    // identifier word (so regex-position keywords like `return` are recognized).
+    const VALUE: u8 = b'a';
+    let mut prev: Option<u8> = None;
+    let mut prev_word: Option<&str> = None;
     while index < span.len() {
-        match bytes[index] {
+        let byte = bytes[index];
+        if is_ident_byte(byte) {
+            // Consume a whole identifier/number word as one token.  A word right
+            // after `.` (or `?.`) is a property name, not a keyword, so it must
+            // not enable regex position (e.g. `obj.return / …`).
+            let after_member_access = prev == Some(b'.');
+            let word_start = index;
+            while index < span.len() && is_ident_byte(bytes[index]) {
+                index += 1;
+            }
+            prev = Some(VALUE);
+            prev_word = if after_member_access {
+                None
+            } else {
+                Some(&span[word_start..index])
+            };
+            continue;
+        }
+        match byte {
             b'{' => {
                 depth += 1;
                 index += 1;
+                prev = Some(b'{');
+                prev_word = None;
             }
             b'}' => {
                 depth -= 1;
                 index += 1;
                 if depth == 0 {
-                    return Some(index);
+                    return BraceScan::Closed(index);
                 }
+                prev = Some(b'}');
+                prev_word = None;
             }
             b'"' | b'\'' | b'`' => {
-                index = skip_string(span, index)?;
+                let Some(after) = skip_string(span, index) else {
+                    return BraceScan::Unbalanced;
+                };
+                index = after;
+                prev = Some(VALUE); // a string is a value: a following `/` is division
+                prev_word = None;
             }
             b'/' if let Some(after) = skip_comment(span, index) => {
-                index = after;
+                index = after; // comments do not change the preceding token
             }
+            b'/' if prev == Some(b'}') => {
+                // A `/` right after `}` is genuinely ambiguous without a JS
+                // parser: regex after a block close, or division after an object
+                // literal.  Rather than guess (and risk miscounting a `}` inside
+                // a regex character class), give up and leave the whole
+                // expression to comrak.
+                return BraceScan::Ambiguous;
+            }
+            b'/' if allows_regex(prev, prev_word) => {
+                if let Some(after) = skip_regex(span, index) {
+                    index = after;
+                    prev = Some(VALUE); // a regex is a value: a following `/` is division
+                } else {
+                    index += 1;
+                    prev = Some(b'/');
+                }
+                prev_word = None;
+            }
+            b' ' | b'\t' | b'\n' | b'\r' => index += 1,
+            other => {
+                prev = Some(other);
+                prev_word = None;
+                index += char_len(other);
+            }
+        }
+    }
+    BraceScan::Unbalanced
+}
+
+/// Keywords after which a `/` begins a regex literal (expression position).
+fn is_regex_keyword(word: &str) -> bool {
+    matches!(
+        word,
+        "return"
+            | "throw"
+            | "yield"
+            | "await"
+            | "typeof"
+            | "void"
+            | "delete"
+            | "in"
+            | "of"
+            | "instanceof"
+            | "new"
+            | "do"
+            | "case"
+            | "else"
+    )
+}
+
+/// Whether a `/` following the most recent token begins a regex literal (rather
+/// than a division operator).  A regex appears in "expression position": at the
+/// start, after an operator or opening bracket, or after a regex-position
+/// keyword such as `return`.  A `/` after a value (identifier, number, string,
+/// `)`, `]`) is division.  The genuinely ambiguous `/`-after-`}` case is handled
+/// separately by the caller (which gives up rather than guess).
+///
+/// This is a heuristic; a misclassified division is only attempted as a regex,
+/// and if no valid regex terminator follows, [`skip_regex`] returns `None` and
+/// the caller falls back to treating the `/` as division.
+fn allows_regex(prev: Option<u8>, prev_word: Option<&str>) -> bool {
+    match prev {
+        None => true,
+        // A value token: only a regex-position keyword allows a regex.
+        Some(b'a') => prev_word.is_some_and(is_regex_keyword),
+        Some(byte) => matches!(
+            byte,
+            b'(' | b','
+                | b'='
+                | b'['
+                | b'{'
+                | b':'
+                | b';'
+                | b'!'
+                | b'&'
+                | b'|'
+                | b'?'
+                | b'+'
+                | b'-'
+                | b'*'
+                | b'%'
+                | b'^'
+                | b'~'
+                | b'<'
+                | b'>'
+                | b'/'
+        ),
+    }
+}
+
+/// Skip a JavaScript regex literal starting at `start` (a `/`).  Returns the byte
+/// offset just past the closing `/` and any flags.  A `/` inside a `[…]`
+/// character class does not close the regex.  Returns `None` if the literal does
+/// not terminate on its line (regex literals cannot span lines).
+fn skip_regex(span: &str, start: usize) -> Option<usize> {
+    let bytes = span.as_bytes();
+    let mut index = start + 1;
+    let mut in_class = false;
+    while index < span.len() {
+        match bytes[index] {
+            b'\\' => {
+                index += 1;
+                if index < span.len() {
+                    index += char_len(bytes[index]);
+                }
+            }
+            b'[' => {
+                in_class = true;
+                index += 1;
+            }
+            b']' => {
+                in_class = false;
+                index += 1;
+            }
+            b'/' if !in_class => {
+                index += 1;
+                while index < span.len() && bytes[index].is_ascii_alphabetic() {
+                    index += 1;
+                }
+                return Some(index);
+            }
+            b'\n' => return None,
             byte => index += char_len(byte),
         }
     }
     None
 }
 
-/// If a JSX element or fragment that comrak would otherwise corrupt starts at
-/// `start` (a `<`), return the byte offset just past its end.
+/// Outcome of scanning for a JSX element or fragment at a given `<`.
+#[derive(Debug, PartialEq, Eq)]
+enum JsxScan {
+    /// A protectable construct ending just past the byte offset.
+    Matched(usize),
+    /// A protect-worthy construct that could not be delimited; skip the rest of
+    /// the span rather than risk protecting part of it.
+    GiveUp,
+    /// Not a protectable construct here (advance one character and continue).
+    NoMatch,
+}
+
+/// Classify a JSX element or fragment starting at `start` (a `<`).
 ///
 /// A construct is protected only when comrak misparses it: a fragment (`<>…</>`),
 /// or an element whose opening tag carries a `{…}` expression attribute or spans
-/// multiple lines.  A plain single-line HTML-shaped tag (e.g. `<Chart x="y" />`)
-/// is already preserved verbatim by comrak, so it is left untouched (returns
-/// `None`).  Autolinks (`<https://…>`) and stray `<` in prose also return `None`.
+/// multiple lines.  A plain single-line HTML-shaped tag (e.g. `<Chart x="y" />`),
+/// an autolink (`<https://…>`), or a stray `<` in prose is [`JsxScan::NoMatch`]
+/// (comrak handles it, and the caller keeps scanning for nested constructs).
 ///
 /// Container elements are protected as a whole (opening tag through the matching
 /// closing tag), consistent with comrak's existing treatment of tag-based JSX;
 /// the embedded JSX is preserved rather than reformatted.  String literals and
 /// `{…}` expressions (which may themselves contain `<`/`>`) are skipped while
-/// matching tags.  Returns `None` for anything that cannot be delimited as a
-/// balanced construct within the span (do-no-harm).
-fn scan_jsx(span: &str, start: usize) -> Option<usize> {
+/// matching tags.  Once the root is known to be protect-worthy, any failure to
+/// delimit it returns [`JsxScan::GiveUp`] so no nested fragment is protected on
+/// its own.
+fn scan_jsx(span: &str, start: usize) -> JsxScan {
     let bytes = span.as_bytes();
     // Must be able to begin a JSX construct: `<>` or `<` + tag name.
     match bytes.get(start + 1) {
         Some(b'>') => {}
         Some(&byte) if byte.is_ascii_alphabetic() => {}
-        _ => return None,
+        _ => return JsxScan::NoMatch,
     }
 
     // The protection decision depends only on the *root* construct: comrak
@@ -559,29 +846,36 @@ fn scan_jsx(span: &str, start: usize) -> Option<usize> {
     // A plain root tag (even a container) is preserved by comrak as-is, so it is
     // left alone — the caller then scans its children, where any nested
     // expression/JSX is protected independently and prose stays formatted.
-    let root = scan_open_tag(span, start)?;
+    let root = match scan_open_tag(span, start) {
+        OpenTagScan::Parsed(tag) => tag,
+        OpenTagScan::GiveUp => return JsxScan::GiveUp,
+        OpenTagScan::NoMatch => return JsxScan::NoMatch,
+    };
     if !(root.is_fragment || root.has_expression || root.multiline) {
-        return None;
+        return JsxScan::NoMatch;
     }
     if root.self_closing {
-        return Some(root.end);
+        return JsxScan::Matched(root.end);
     }
 
     // Protected container: scan to the matching closing tag, tracking nesting.
     // Nested tags' own attributes do not affect the (already decided) protection.
+    // Any failure to delimit gives up, since the root is protect-worthy.
     let mut stack: Vec<&str> = vec![root.name];
     let mut index = root.end;
     while index < span.len() {
         match bytes[index] {
             b'<' if bytes.get(index + 1) == Some(&b'/') => {
-                let (name, after) = read_close_tag(span, index)?;
+                let Some((name, after)) = read_close_tag(span, index) else {
+                    return JsxScan::GiveUp;
+                };
                 match stack.pop() {
                     Some(open) if open == name => {}
-                    _ => return None, // mismatched or stray close tag
+                    _ => return JsxScan::GiveUp, // mismatched or stray close tag
                 }
                 index = after;
                 if stack.is_empty() {
-                    return Some(index);
+                    return JsxScan::Matched(index);
                 }
             }
             b'<' if matches!(bytes.get(index + 1), Some(b'>'))
@@ -589,21 +883,58 @@ fn scan_jsx(span: &str, start: usize) -> Option<usize> {
                     .get(index + 1)
                     .is_some_and(|b| b.is_ascii_alphabetic()) =>
             {
-                let tag = scan_open_tag(span, index)?;
-                index = tag.end;
-                if !tag.self_closing {
-                    stack.push(tag.name);
+                match scan_open_tag(span, index) {
+                    OpenTagScan::Parsed(tag) => {
+                        index = tag.end;
+                        if !tag.self_closing {
+                            stack.push(tag.name);
+                        }
+                    }
+                    _ => return JsxScan::GiveUp,
                 }
             }
             b'<' => index += 1, // a literal `<` in element children
             b'{' => {
                 // A `{…}` expression among element children.
-                index = skip_braces(span, index)?;
+                match skip_braces(span, index) {
+                    BraceScan::Closed(after) => index = after,
+                    _ => return JsxScan::GiveUp,
+                }
             }
             byte => index += char_len(byte),
         }
     }
-    None
+    JsxScan::GiveUp
+}
+
+/// Outcome of scanning for a bare `{…}` expression at a given `{`.
+#[derive(Debug, PartialEq, Eq)]
+enum ExprScan {
+    /// A protectable expression ending just past the byte offset.
+    Matched(usize),
+    /// An ambiguous expression: skip the rest of the span rather than risk
+    /// protecting part of it.
+    GiveUp,
+    /// Not a protectable expression here (advance one character and continue).
+    NoMatch,
+}
+
+/// Classify a bare `{…}` JSX expression starting at `start` (a `{`).
+///
+/// A heading anchor `{#identifier}` (a Hongdown feature) and an unbalanced `{`
+/// are [`ExprScan::NoMatch`].  A `{…}` whose internal `/`-after-`}` cannot be
+/// classified is [`ExprScan::GiveUp`] (the caller then stops scanning the span so
+/// no nested fragment is protected in isolation).
+fn scan_expression(span: &str, start: usize) -> ExprScan {
+    // `{#…}` at the end of a heading is an explicit anchor, not an expression.
+    if span.as_bytes().get(start + 1) == Some(&b'#') {
+        return ExprScan::NoMatch;
+    }
+    match skip_braces(span, start) {
+        BraceScan::Closed(end) => ExprScan::Matched(end),
+        BraceScan::Ambiguous => ExprScan::GiveUp,
+        BraceScan::Unbalanced => ExprScan::NoMatch,
+    }
 }
 
 /// Skip a string literal that starts at `start` (a `"`, `'`, or `` ` `` quote).
@@ -674,6 +1005,24 @@ mod tests {
     /// somewhere in the protected source's replacement map.
     fn protect_source(source: &str) -> Option<(String, Vec<Protected>)> {
         protect(source, &comrak_options())
+    }
+
+    /// The end offset of a matched bare expression at the start of `span`, or
+    /// `None` for give-up/no-match.
+    fn expr_end(span: &str) -> Option<usize> {
+        match scan_expression(span, 0) {
+            ExprScan::Matched(end) => Some(end),
+            _ => None,
+        }
+    }
+
+    /// The end offset of a matched JSX construct at the start of `span`, or `None`
+    /// for give-up/no-match.
+    fn jsx_end(span: &str) -> Option<usize> {
+        match scan_jsx(span, 0) {
+            JsxScan::Matched(end) => Some(end),
+            _ => None,
+        }
     }
 
     #[test]
@@ -791,44 +1140,47 @@ mod tests {
     #[test]
     fn scan_jsx_self_closing_with_expression_attr() {
         let span = "<Chart data={data} />";
-        assert_eq!(scan_jsx(span, 0), Some(span.len()));
+        assert_eq!(jsx_end(span), Some(span.len()));
     }
 
     #[test]
     fn scan_jsx_plain_self_closing_not_protected() {
         // A complete single-line tag is already preserved verbatim by comrak.
-        assert_eq!(scan_jsx("<Chart data=\"x\" />", 0), None);
+        assert_eq!(jsx_end("<Chart data=\"x\" />"), None);
     }
 
     #[test]
     fn scan_jsx_multiline_self_closing() {
         let span = "<PackageManagerTabs\n  command={{ npm: \"x\" }}\n/>";
-        assert_eq!(scan_jsx(span, 0), Some(span.len()));
+        assert_eq!(jsx_end(span), Some(span.len()));
     }
 
     #[test]
     fn scan_jsx_multiline_open_tag_without_expression() {
         let span = "<Chart\n  data=\"x\"\n/>";
-        assert_eq!(scan_jsx(span, 0), Some(span.len()));
+        assert_eq!(jsx_end(span), Some(span.len()));
     }
 
     #[test]
     fn scan_jsx_fragment() {
         let span = "<>hello</>";
-        assert_eq!(scan_jsx(span, 0), Some(span.len()));
+        assert_eq!(jsx_end(span), Some(span.len()));
     }
 
     #[test]
     fn scan_jsx_container_with_expression_attr() {
-        let span = "<Tabs value={selected}>content</Tabs>";
-        assert_eq!(scan_jsx(span, 0), Some(span.len()));
+        // A `{{…}}` object attribute is not valid inline HTML, so the whole
+        // container is protected (a simple `{x}` attribute would instead be left
+        // to comrak as inline HTML — see the integration tests).
+        let span = "<Tabs value={{ id }}>content</Tabs>";
+        assert_eq!(jsx_end(span), Some(span.len()));
     }
 
     #[test]
     fn scan_jsx_plain_container_not_protected() {
         // comrak preserves the tags; any expression children are handled
         // separately by the expression scanner.
-        assert_eq!(scan_jsx("<Tabs>content</Tabs>", 0), None);
+        assert_eq!(jsx_end("<Tabs>content</Tabs>"), None);
     }
 
     #[test]
@@ -836,19 +1188,19 @@ mod tests {
         // The root tag is plain, so the whole container is not protected even
         // though a child has an expression attribute — the child is protected
         // separately and the prose between tags stays formattable.
-        assert_eq!(scan_jsx("<Note>x <Badge count={n} /></Note>", 0), None);
+        assert_eq!(jsx_end("<Note>x <Badge count={n} /></Note>"), None);
     }
 
     #[test]
     fn scan_jsx_double_brace_attribute() {
         let span = "<Foo style={{ color: \"red\" }} />";
-        assert_eq!(scan_jsx(span, 0), Some(span.len()));
+        assert_eq!(jsx_end(span), Some(span.len()));
     }
 
     #[test]
     fn scan_jsx_nested_self_closing_in_braced_container() {
         let span = "<Foo bar={1}><Baz/></Foo>";
-        assert_eq!(scan_jsx(span, 0), Some(span.len()));
+        assert_eq!(jsx_end(span), Some(span.len()));
     }
 
     #[test]
@@ -856,31 +1208,188 @@ mod tests {
         // The `<Bar/>` lives inside an attribute expression; the element is
         // protected as a whole via its `{…}` attribute.
         let span = "<Foo render={() => <Bar/>} />";
-        assert_eq!(scan_jsx(span, 0), Some(span.len()));
+        assert_eq!(jsx_end(span), Some(span.len()));
     }
 
     #[test]
     fn scan_jsx_attribute_string_with_angle_and_brace_not_protected() {
         // `>` and `{` live in a quoted attribute, so comrak parses the tag fine.
-        assert_eq!(scan_jsx("<Foo title=\"a > b {c}\" />", 0), None);
+        assert_eq!(jsx_end("<Foo title=\"a > b {c}\" />"), None);
     }
 
     #[test]
     fn scan_jsx_rejects_comparison_and_non_tag() {
-        assert_eq!(scan_jsx("< b", 0), None);
-        assert_eq!(scan_jsx("<3 ideas", 0), None);
-        assert_eq!(scan_jsx("</close>", 0), None);
+        assert_eq!(jsx_end("< b"), None);
+        assert_eq!(jsx_end("<3 ideas"), None);
+        assert_eq!(jsx_end("</close>"), None);
     }
 
     #[test]
     fn scan_jsx_rejects_autolink() {
-        assert_eq!(scan_jsx("<https://example.com>", 0), None);
-        assert_eq!(scan_jsx("<user@example.com>", 0), None);
+        assert_eq!(jsx_end("<https://example.com>"), None);
+        assert_eq!(jsx_end("<user@example.com>"), None);
     }
 
     #[test]
-    fn scan_jsx_unterminated_returns_none() {
-        assert_eq!(scan_jsx("<Foo bar={1}>no close", 0), None);
+    fn scan_jsx_unterminated_gives_up() {
+        // A protect-worthy container with no matching close cannot be delimited;
+        // give up rather than partially protect.
+        assert_eq!(scan_jsx("<Foo bar={1}>no close", 0), JsxScan::GiveUp);
+    }
+
+    #[test]
+    fn scan_expression_simple() {
+        let span = "{count}";
+        assert_eq!(expr_end(span), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_expression_member_access() {
+        let span = "{user.name}";
+        assert_eq!(expr_end(span), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_expression_nested_braces() {
+        let span = "{outer {inner} done}";
+        assert_eq!(expr_end(span), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_expression_comment_with_quotes() {
+        let span = "{/* a comment with \"quotes\" */}";
+        assert_eq!(expr_end(span), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_expression_string_with_brace() {
+        // A `}` inside a string must not close the expression early.
+        let span = "{label(\"a } b\")}";
+        assert_eq!(expr_end(span), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_expression_heading_anchor_excluded() {
+        // `{#id}` is a Hongdown heading anchor, not an MDX expression.
+        assert_eq!(scan_expression("{#my-id}", 0), ExprScan::NoMatch);
+    }
+
+    #[test]
+    fn scan_expression_unbalanced_returns_none() {
+        assert_eq!(scan_expression("{ unbalanced", 0), ExprScan::NoMatch);
+    }
+
+    #[test]
+    fn scan_expression_regex_with_brace_in_class() {
+        // A `}` inside a regex character class must not close the expression.
+        let span = "{value.replace(/[}]/g, \"x\")}";
+        assert_eq!(expr_end(span), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_expression_regex_with_brace_quantifier() {
+        let span = "{/\\d{2,4}/.test(s)}";
+        assert_eq!(expr_end(span), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_expression_division_is_not_regex() {
+        // `/` after a value is division, not a regex; the expression still
+        // balances normally.
+        let span = "{a / b / c}";
+        assert_eq!(expr_end(span), Some(span.len()));
+    }
+
+    #[test]
+    fn skip_regex_handles_character_class() {
+        let span = "/[}/]/g";
+        assert_eq!(skip_regex(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_expression_regex_after_keyword() {
+        // A regex right after `return` (a keyword) must be recognized, so the
+        // `}` in its character class does not end the expression early.
+        let span = "{() => { return /[}]/.test(s); }}";
+        assert_eq!(expr_end(span), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_expression_division_after_identifier_keyword_lookalike() {
+        // `returnValue` is an identifier, not the `return` keyword, so `/` is
+        // division — the expression still balances.
+        let span = "{returnValue / 2}";
+        assert_eq!(expr_end(span), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_expression_keyword_as_property_is_division() {
+        // `return` used as a property name (`obj.return`) is not a keyword, so the
+        // following `/` is division and the later regex's `}` is handled.
+        let span = "{obj.return / /[}]/.source}";
+        assert_eq!(expr_end(span), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_expression_slash_after_brace_gives_up() {
+        // A `/` right after `}` is ambiguous (regex after a block close vs.
+        // division after an object literal); we give up rather than guess.
+        assert_eq!(
+            scan_expression("{() => { if (x) {} /[}]/.test(s); }}", 0),
+            ExprScan::GiveUp
+        );
+        assert_eq!(
+            scan_expression("{{a:1} / b / /[}]/.source}", 0),
+            ExprScan::GiveUp
+        );
+    }
+
+    #[test]
+    fn scan_expression_division_after_object_literal() {
+        let span = "{foo({a:1}) / 2}";
+        assert_eq!(expr_end(span), Some(span.len()));
+    }
+
+    #[test]
+    fn protect_gives_up_on_jsx_with_ambiguous_child_without_partial() {
+        // A protect-worthy container whose child expression is ambiguous must not
+        // have the `{{ ok }}` in its opening tag protected in isolation.
+        let source = "<Foo prop={{ ok }}>{() => { if (x) {} /[}]/.test(s); }}</Foo>\n";
+        assert!(protect_source(source).is_none());
+    }
+
+    #[test]
+    fn protect_gives_up_on_ambiguous_expression_without_partial() {
+        // The inner `{a:1}` of an ambiguous expression must not be protected on
+        // its own when the whole expression is given up.
+        assert!(protect_source("Obj {{a:1} / b / /[}]/.source} weird.\n").is_none());
+        // A real expression before the ambiguous one is still protected; the
+        // inner braces of the ambiguous one are not.
+        let (_, map) =
+            protect_source("Pre {realA} then {{a:1} / b / /[}]/.x} end.\n").expect("realA");
+        assert_eq!(map.len(), 1);
+        assert_eq!(map[0].original, "{realA}");
+    }
+
+    #[test]
+    fn protect_skips_braces_in_inline_code() {
+        // `{x}` inside an inline code span is preserved by comrak verbatim, so it
+        // must not be protected.
+        assert!(protect_source("Use `{x}` in code.\n").is_none());
+    }
+
+    #[test]
+    fn protect_skips_braces_in_math() {
+        // Braces inside `$…$` math are part of the formula, not an expression.
+        assert!(protect_source("The value $\\frac{1}{2}$ is a half.\n").is_none());
+    }
+
+    #[test]
+    fn protect_records_expression_verbatim() {
+        let source = "Hello {user.name}, welcome!\n";
+        let (_, map) = protect_source(source).expect("should protect");
+        assert_eq!(map.len(), 1);
+        assert_eq!(map[0].original, "{user.name}");
     }
 
     #[test]

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -516,7 +516,9 @@ fn finish_esm(end: usize, needs_from: bool, saw_from: bool) -> Option<usize> {
 
 /// If a `//` line comment or `/* … */` block comment starts at `start`, return
 /// the byte offset just past it.  A line comment stops at — but does not consume
-/// — the terminating newline.  Returns `None` when no comment starts there.
+/// — the terminating newline (a line comment that runs to the end of the span is
+/// complete).  Returns `None` when no comment starts there, or when a block
+/// comment is left unterminated (no closing `*/`).
 fn skip_comment(span: &str, start: usize) -> Option<usize> {
     let bytes = span.as_bytes();
     match (bytes.get(start), bytes.get(start + 1)) {
@@ -535,9 +537,10 @@ fn skip_comment(span: &str, start: usize) -> Option<usize> {
                 index += char_len(bytes[index]);
             }
             if index < span.len() {
-                index += 2; // consume the closing `*/`
+                Some(index + 2) // consume the closing `*/`
+            } else {
+                None // unterminated block comment
             }
-            Some(index)
         }
         _ => None,
     }
@@ -1515,6 +1518,18 @@ mod tests {
     fn skip_string_handles_escapes() {
         let span = r#""a\"b""#; // "a\"b"
         assert_eq!(skip_string(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn skip_comment_block_and_line() {
+        // A closed block comment is skipped past its `*/`.
+        assert_eq!(skip_comment("/* x */y", 0), Some("/* x */".len()));
+        // A line comment that runs to the end of the span is complete.
+        assert_eq!(skip_comment("// done", 0), Some("// done".len()));
+        // An unterminated block comment is not a complete comment.
+        assert_eq!(skip_comment("/* x", 0), None);
+        // Not a comment.
+        assert_eq!(skip_comment("/ x", 0), None);
     }
 
     #[test]

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -1,0 +1,585 @@
+//! MDX mode: protect MDX-only constructs from comrak's CommonMark parsing.
+//!
+//! comrak is a plain CommonMark + GFM parser with no knowledge of MDX's
+//! JavaScript/JSX constructs — ESM `import`/`export` statements, JSX elements
+//! and fragments, and `{…}` expressions.  Left to comrak, those constructs are
+//! parsed as ordinary paragraph text and then corrupted by Hongdown's
+//! punctuation transforms (straight quotes become curly) and Markdown escaping
+//! (`*` and `` ` `` get backslash-escaped), with their indentation collapsed.
+//!
+//! This module implements a protective pre/post-processing pass.  Before the
+//! source is handed to comrak, [`protect`] detects the constructs comrak
+//! mangles and replaces each with a unique HTML-comment placeholder, recording
+//! the original text.  comrak emits HTML comments verbatim (as `HtmlBlock` /
+//! `HtmlInline`), so the placeholders survive serialization untouched while the
+//! surrounding Markdown prose is formatted normally.  [`restore`] then swaps the
+//! placeholders back for their original text.
+//!
+//! The detection is AST-guided: only the source spans of `Paragraph` and
+//! `Heading` nodes are scanned.  Content inside fenced/indented code blocks,
+//! inline code spans, math, front matter, and HTML blocks never becomes
+//! paragraph text in comrak's AST, so it is naturally left untouched — we only
+//! ever touch what comrak would otherwise corrupt.
+
+use comrak::nodes::{NodeValue, Sourcepos};
+use comrak::{Arena, Options as ComrakOptions, parse_document};
+
+/// A protected region: the placeholder token that stands in for an MDX
+/// construct during formatting, and the original verbatim text to restore.
+pub(crate) struct Protected {
+    token: String,
+    original: String,
+}
+
+/// Detect MDX constructs in `source` and replace each with a unique HTML-comment
+/// placeholder, returning the protected source and the replacement map.
+///
+/// Returns `None` when there is nothing to protect (the caller then formats the
+/// original source normally).  This is also the do-no-harm fallback: any
+/// construct that cannot be delimited confidently is simply left unprotected
+/// rather than guessed at.
+pub(crate) fn protect(
+    source: &str,
+    comrak_options: &ComrakOptions,
+) -> Option<(String, Vec<Protected>)> {
+    let arena = Arena::new();
+    let root = parse_document(&arena, source, comrak_options);
+    let line_starts = build_line_starts(source);
+
+    // Collect absolute byte ranges of every construct found in a scanned span.
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    for node in root.descendants() {
+        let (is_target, sourcepos) = {
+            let data = node.data.borrow();
+            let is_target = matches!(data.value, NodeValue::Paragraph | NodeValue::Heading(_));
+            (is_target, data.sourcepos)
+        };
+        if !is_target {
+            continue;
+        }
+        let Some((start, end)) = span_bytes(source, &line_starts, sourcepos) else {
+            continue;
+        };
+        let span = &source[start..end];
+        for (relative_start, relative_end) in find_constructs(span) {
+            ranges.push((start + relative_start, start + relative_end));
+        }
+    }
+
+    if ranges.is_empty() {
+        return None;
+    }
+
+    ranges.sort_by_key(|&(start, _)| start);
+
+    let nonce = choose_nonce(source);
+    let mut protected = String::with_capacity(source.len());
+    let mut map = Vec::with_capacity(ranges.len());
+    let mut cursor = 0;
+    for (index, &(start, end)) in ranges.iter().enumerate() {
+        // Defensively skip any range that overlaps an already-protected one.
+        if start < cursor {
+            continue;
+        }
+        protected.push_str(&source[cursor..start]);
+        let token = format!("<!--hongdown-mdx:{nonce}:{index}-->");
+        protected.push_str(&token);
+        map.push(Protected {
+            token,
+            original: source[start..end].to_string(),
+        });
+        cursor = end;
+    }
+    protected.push_str(&source[cursor..]);
+
+    Some((protected, map))
+}
+
+/// Replace every placeholder token in `output` with its original text.
+pub(crate) fn restore(output: &str, map: &[Protected]) -> String {
+    let mut result = output.to_string();
+    for protected in map {
+        result = result.replace(&protected.token, &protected.original);
+    }
+    result
+}
+
+/// Byte offsets of the start of each line in `source` (1-indexed line `n` lives
+/// at `line_starts[n - 1]`).
+fn build_line_starts(source: &str) -> Vec<usize> {
+    let mut starts = vec![0usize];
+    for (index, byte) in source.bytes().enumerate() {
+        if byte == b'\n' {
+            starts.push(index + 1);
+        }
+    }
+    starts
+}
+
+/// Convert a node's [`Sourcepos`] to an absolute `[start, end)` byte range in
+/// `source`.  comrak reports 1-indexed, byte-based line/column positions with an
+/// inclusive end column.  Returns `None` if the position is unset or does not
+/// land on character boundaries (do-no-harm: skip the node).
+fn span_bytes(source: &str, line_starts: &[usize], sourcepos: Sourcepos) -> Option<(usize, usize)> {
+    let start_line = sourcepos.start.line;
+    let end_line = sourcepos.end.line;
+    if start_line == 0
+        || end_line == 0
+        || start_line > line_starts.len()
+        || end_line > line_starts.len()
+    {
+        return None;
+    }
+    let start =
+        line_starts[start_line - 1].checked_add(sourcepos.start.column.saturating_sub(1))?;
+    let end = line_starts[end_line - 1].checked_add(sourcepos.end.column)?;
+    if start > end || end > source.len() {
+        return None;
+    }
+    if !source.is_char_boundary(start) || !source.is_char_boundary(end) {
+        return None;
+    }
+    Some((start, end))
+}
+
+/// Find MDX construct ranges (byte offsets relative to `span`) within a single
+/// scanned span.  Scanning is bounded to the span: a construct that is not
+/// fully contained in it is not matched.  In particular an ESM statement with a
+/// blank line inside its body is split by comrak into separate paragraphs, so it
+/// is left unprotected (a documented limitation) rather than scanning into
+/// unrelated later content.
+///
+/// Currently detects ESM `import`/`export` statements; JSX elements and `{…}`
+/// expressions are added incrementally.
+fn find_constructs(span: &str) -> Vec<(usize, usize)> {
+    let bytes = span.as_bytes();
+    let mut ranges = Vec::new();
+    let mut index = 0;
+    let mut at_line_start = true;
+    while index < span.len() {
+        if at_line_start {
+            // CommonMark paragraphs allow up to three leading spaces.
+            let mut scan = index;
+            let mut spaces = 0;
+            while scan < span.len() && bytes[scan] == b' ' && spaces < 3 {
+                scan += 1;
+                spaces += 1;
+            }
+            if let Some(end) = scan_esm(span, scan) {
+                ranges.push((scan, end));
+                index = end;
+                at_line_start = bytes.get(index) == Some(&b'\n');
+                continue;
+            }
+        }
+        if bytes[index] == b'\n' {
+            at_line_start = true;
+            index += 1;
+        } else {
+            at_line_start = false;
+            index += char_len(bytes[index]);
+        }
+    }
+    ranges
+}
+
+/// Keywords that may follow `export` to form an export declaration.
+const EXPORT_DECLARATIONS: &[&str] = &[
+    "default",
+    "const",
+    "let",
+    "var",
+    "function",
+    "class",
+    "async",
+    "type",
+    "interface",
+    "enum",
+    "abstract",
+    "declare",
+    "namespace",
+    "module",
+];
+
+/// Whether `byte` can appear inside a JavaScript identifier.
+fn is_ident_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || byte == b'_' || byte == b'$'
+}
+
+/// Read the identifier word starting at `pos` (empty if `pos` is not an
+/// identifier start).
+fn read_word(source: &str, pos: usize) -> &str {
+    let bytes = source.as_bytes();
+    let mut end = pos;
+    while end < source.len() && is_ident_byte(bytes[end]) {
+        end += 1;
+    }
+    &source[pos..end]
+}
+
+/// Whether `word` occurs at byte offset `at` as a standalone token (bounded by
+/// non-identifier bytes on both sides).
+fn is_word_at(bytes: &[u8], at: usize, word: &[u8]) -> bool {
+    if at + word.len() > bytes.len() || &bytes[at..at + word.len()] != word {
+        return false;
+    }
+    let before_ok = at == 0 || !is_ident_byte(bytes[at - 1]);
+    let after_ok = at + word.len() >= bytes.len() || !is_ident_byte(bytes[at + word.len()]);
+    before_ok && after_ok
+}
+
+/// If an ESM `import`/`export` statement starts at `start` within `span`, return
+/// the byte offset just past its end (before the terminating newline).
+///
+/// The statement is consumed across the lines of the span while bracket depth is
+/// positive, so multi-line imports and `export const … = {…}` objects are
+/// handled.  Scanning is bounded to the span: an object whose body contains a
+/// blank line is split by comrak into separate paragraphs and therefore is not
+/// fully contained in any one span, so it is left unprotected (a documented
+/// limitation) rather than scanning into unrelated later content.  String
+/// literals, line comments (`//`), and block comments (`/* … */`) are skipped so
+/// that `{`/`}`/`<`/`>` inside them do not affect the brace-depth scan.
+///
+/// To avoid protecting ordinary prose that merely begins with the word
+/// "import"/"export", the statement form is validated: `export` must be followed
+/// by `{`, `*`, or a declaration keyword (`const`, `default`, `function`, …);
+/// `import` must be a side-effect string import or carry a `from` clause whose
+/// specifier is a string.  Returns `None` when the form is not valid ESM, or when
+/// the brackets are still unbalanced at the end of the span (do-no-harm: leave
+/// ambiguous input unprotected rather than guess).
+fn scan_esm(span: &str, start: usize) -> Option<usize> {
+    let bytes = span.as_bytes();
+    let rest = &span[start..];
+    let is_import = rest.starts_with("import");
+    if !is_import && !rest.starts_with("export") {
+        return None;
+    }
+    let after = start + "import".len();
+    // The character after the keyword must be plausible ESM, not the tail of an
+    // identifier ("important", "exports") or sentence punctuation ("import.").
+    match bytes.get(after) {
+        Some(b' ' | b'\t' | b'{' | b'*' | b'(' | b'"' | b'\'') => {}
+        _ => return None,
+    }
+    // The first meaningful token after the keyword (skipping spaces/tabs).
+    let mut token = after;
+    while token < span.len() && matches!(bytes[token], b' ' | b'\t') {
+        token += 1;
+    }
+    if token >= span.len() || bytes[token] == b'\n' {
+        // Bare keyword line ("import"/"export" with nothing after it) is prose.
+        return None;
+    }
+    let first = bytes[token];
+
+    // Validate the statement form and decide whether a `from` clause is required.
+    let mut needs_from = false;
+    if is_import {
+        match first {
+            b'"' | b'\'' => {}      // side-effect import: `import "module"`
+            b'(' => return None,    // dynamic `import(...)` is an expression, not flow ESM
+            _ => needs_from = true, // named / default / namespace import
+        }
+    } else if first != b'{' && first != b'*' {
+        // `export <declaration>`: the word must be a real declaration keyword.
+        if !EXPORT_DECLARATIONS.contains(&read_word(span, token)) {
+            return None;
+        }
+    }
+
+    let mut index = after;
+    let mut depth: i32 = 0;
+    let mut saw_from = false;
+    while index < span.len() {
+        match bytes[index] {
+            b'"' | b'\'' | b'`' => {
+                index = skip_string(span, index)?;
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'/') => {
+                // Line comment: skip to (but not past) the end of the line so the
+                // newline arm still sees it for the depth check.
+                index += 2;
+                while index < span.len() && bytes[index] != b'\n' {
+                    index += char_len(bytes[index]);
+                }
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'*') => {
+                // Block comment: skip to the closing `*/`.
+                index += 2;
+                while index < span.len()
+                    && !(bytes[index] == b'*' && bytes.get(index + 1) == Some(&b'/'))
+                {
+                    index += char_len(bytes[index]);
+                }
+                if index < span.len() {
+                    index += 2;
+                }
+            }
+            b'{' | b'(' | b'[' => {
+                depth += 1;
+                index += 1;
+            }
+            b'}' | b')' | b']' => {
+                depth -= 1;
+                index += 1;
+            }
+            b'\n' => {
+                if depth <= 0 {
+                    return finish_esm(index, needs_from, saw_from);
+                }
+                index += 1;
+            }
+            b'f' if needs_from && !saw_from && is_word_at(bytes, index, b"from") => {
+                // A genuine `from` clause is followed by the module string
+                // specifier, e.g. `from "./x"`.  Requiring the string rejects
+                // ordinary prose such as "import these ideas from elsewhere."
+                let mut probe = index + 4;
+                while probe < span.len() && matches!(bytes[probe], b' ' | b'\t') {
+                    probe += 1;
+                }
+                if matches!(bytes.get(probe), Some(b'"' | b'\'' | b'`')) {
+                    saw_from = true;
+                }
+                index += 4;
+            }
+            _ => index += char_len(bytes[index]),
+        }
+    }
+    // Reached the end of the span: complete only if brackets balanced out.
+    if depth <= 0 {
+        finish_esm(span.len(), needs_from, saw_from)
+    } else {
+        None
+    }
+}
+
+/// Resolve the end of an ESM statement: a statement that requires a `from`
+/// clause must have seen one to count as ESM.
+fn finish_esm(end: usize, needs_from: bool, saw_from: bool) -> Option<usize> {
+    if needs_from && !saw_from {
+        None
+    } else {
+        Some(end)
+    }
+}
+
+/// Skip a string literal that starts at `start` (a `"`, `'`, or `` ` `` quote).
+/// Returns the byte offset just past the closing quote, or `None` if the string
+/// is unterminated.
+fn skip_string(span: &str, start: usize) -> Option<usize> {
+    let bytes = span.as_bytes();
+    let quote = bytes[start];
+    let mut index = start + 1;
+    while index < span.len() {
+        match bytes[index] {
+            b'\\' => {
+                // Skip the backslash and the (possibly multi-byte) escaped char.
+                index += 1;
+                if index < span.len() {
+                    index += char_len(bytes[index]);
+                }
+            }
+            byte if byte == quote => return Some(index + 1),
+            byte => index += char_len(byte),
+        }
+    }
+    None
+}
+
+/// UTF-8 length in bytes of the character whose leading byte is `byte`.
+fn char_len(byte: u8) -> usize {
+    if byte < 0x80 {
+        1
+    } else if byte >> 5 == 0b110 {
+        2
+    } else if byte >> 4 == 0b1110 {
+        3
+    } else if byte >> 3 == 0b11110 {
+        4
+    } else {
+        1
+    }
+}
+
+/// Choose a placeholder nonce that does not collide with existing text in
+/// `source`.
+fn choose_nonce(source: &str) -> String {
+    let mut nonce = String::from("x");
+    while source.contains(&format!("hongdown-mdx:{nonce}:")) {
+        nonce.push('x');
+    }
+    nonce
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn comrak_options() -> ComrakOptions<'static> {
+        let mut options = ComrakOptions::default();
+        options.extension.front_matter_delimiter = Some("---".to_string());
+        options.extension.table = true;
+        options.extension.description_lists = true;
+        options.extension.alerts = true;
+        options.extension.footnotes = true;
+        options.extension.tasklist = true;
+        options.extension.math_dollars = true;
+        options
+    }
+
+    /// Protect, then assert the round trip restores the original verbatim text
+    /// somewhere in the protected source's replacement map.
+    fn protect_source(source: &str) -> Option<(String, Vec<Protected>)> {
+        protect(source, &comrak_options())
+    }
+
+    #[test]
+    fn scan_esm_single_line_import() {
+        let span = "import { Chart } from \"./chart.js\";";
+        assert_eq!(scan_esm(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_esm_rejects_prose_words() {
+        assert_eq!(scan_esm("important things happen", 0), None);
+        assert_eq!(scan_esm("exporting is fun", 0), None);
+    }
+
+    #[test]
+    fn scan_esm_multiline_import() {
+        let span = "import {\n  a,\n  b,\n} from \"y\";";
+        // Consumes all lines while the brace is open, ending at the final `;`.
+        assert_eq!(scan_esm(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_esm_export_with_object() {
+        let span = "export const meta = { author: 'Hong Minhee' };";
+        assert_eq!(scan_esm(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_esm_string_with_angle_and_brace() {
+        // `>` and `{` inside the string must not derail the scan.
+        let span = "import x from \"a > b { c\";";
+        assert_eq!(scan_esm(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_esm_rejects_bare_keyword_line() {
+        // A line that is just the word "export"/"import" is prose, not ESM.
+        assert_eq!(scan_esm("export", 0), None);
+        assert_eq!(scan_esm("import", 0), None);
+        assert_eq!(scan_esm("export   ", 0), None);
+    }
+
+    #[test]
+    fn scan_esm_skips_brace_in_line_comment() {
+        // A `}` inside a `//` comment must not close the object early.
+        let span = "export const meta = {\n  // }\n  title: \"Hi\",\n};";
+        assert_eq!(scan_esm(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_esm_skips_brace_in_block_comment() {
+        let span = "export const meta = {\n  /* } */\n  title: \"Hi\",\n};";
+        assert_eq!(scan_esm(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_esm_unbalanced_braces_returns_none() {
+        // An import whose brace never closes within the span is ambiguous; leave
+        // it unprotected rather than swallow following content.
+        let span = "import { a from \"x\"";
+        assert_eq!(scan_esm(span, 0), None);
+    }
+
+    #[test]
+    fn scan_esm_side_effect_import() {
+        let span = "import \"./styles.css\";";
+        assert_eq!(scan_esm(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_esm_rejects_prose_starting_with_export_word() {
+        // "export these results from the team" is prose, not an export.
+        assert_eq!(scan_esm("export these results from the team.", 0), None);
+    }
+
+    #[test]
+    fn scan_esm_rejects_prose_import_without_string_specifier() {
+        // "import these ideas from elsewhere." has a `from` not followed by a
+        // module string, so it is prose, not an import.
+        assert_eq!(scan_esm("import these ideas from elsewhere.", 0), None);
+    }
+
+    #[test]
+    fn scan_esm_default_import_with_string_from() {
+        let span = "import Chart from \"./chart.js\";";
+        assert_eq!(scan_esm(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_esm_unterminated_object_in_span_returns_none() {
+        // A span that ends mid-object (open brace) is not a complete statement.
+        // This is the blank-line-split case: comrak ends the paragraph here, so
+        // the object is left unprotected rather than scanning into later prose.
+        let span = "export const meta = {\n  a: 1,";
+        assert_eq!(scan_esm(span, 0), None);
+    }
+
+    #[test]
+    fn protect_does_not_swallow_prose_after_unterminated_object() {
+        // comrak splits this on the blank line; the first paragraph ends
+        // mid-object (depth > 0) so it is not protected, and the prose paragraph
+        // — including its stray `}` — is left to normal formatting.
+        let source = "export const meta = {\n\nProse with } here.\n";
+        assert!(protect_source(source).is_none());
+    }
+
+    #[test]
+    fn protect_skips_prose_starting_with_keyword() {
+        // A paragraph that merely begins with "export"/"import" as prose is not
+        // protected.
+        assert!(protect_source("export these notes from class today.\n").is_none());
+        assert!(protect_source("import more discipline into your life.\n").is_none());
+    }
+
+    #[test]
+    fn skip_string_handles_escapes() {
+        let span = r#""a\"b""#; // "a\"b"
+        assert_eq!(skip_string(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn protect_returns_none_without_constructs() {
+        assert!(protect_source("Just some prose.\n\nMore prose.\n").is_none());
+    }
+
+    #[test]
+    fn protect_records_import_verbatim() {
+        let source = "import { Chart } from \"./chart.js\";\n\nProse.\n";
+        let (protected, map) = protect_source(source).expect("should protect");
+        assert_eq!(map.len(), 1);
+        assert_eq!(map[0].original, "import { Chart } from \"./chart.js\";");
+        assert!(protected.contains("<!--hongdown-mdx:"));
+        assert!(protected.contains("Prose."));
+        assert!(!protected.contains("import {"));
+    }
+
+    #[test]
+    fn restore_round_trips() {
+        let source = "export const meta = { author: 'Hong Minhee' };\n";
+        let (protected, map) = protect_source(source).expect("should protect");
+        let restored = restore(&protected, &map);
+        assert!(restored.contains("export const meta = { author: 'Hong Minhee' };"));
+    }
+
+    #[test]
+    fn protect_skips_code_blocks() {
+        // An import inside a fenced code block is not paragraph text, so it must
+        // not be protected.
+        let source = "~~~~ js\nimport x from \"y\";\n~~~~\n";
+        assert!(protect_source(source).is_none());
+    }
+}

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -847,6 +847,7 @@ fn is_regex_keyword(word: &str) -> bool {
             | "do"
             | "case"
             | "else"
+            | "default"
     )
 }
 
@@ -1202,6 +1203,14 @@ mod tests {
         // `/` after a value is division, not a regex; the statement still ends
         // at its newline.
         let span = "export const ratio = a / b;";
+        assert_eq!(scan_esm(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_esm_export_default_regex() {
+        // `export default /…/` puts a regex right after the `default` keyword;
+        // a `}` in its character class must not be counted as a brace.
+        let span = "export default /[}]/;";
         assert_eq!(scan_esm(span, 0), Some(span.len()));
     }
 

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -31,17 +31,51 @@ pub(crate) struct Protected {
     original: String,
 }
 
+/// The result of [`protect`]: the source to format (with MDX constructs replaced
+/// by placeholders), the replacement map, and a line map from the protected
+/// source back to the original.
+pub(crate) struct Protection {
+    /// The protected source to hand to comrak.
+    pub source: String,
+    /// The placeholder → original replacements.
+    replacements: Vec<Protected>,
+    /// For each protected line `n` (1-indexed), the original line number it came
+    /// from.  Multi-line constructs collapse to a single-line placeholder, so
+    /// without this a warning after one would be reported several lines early.
+    original_lines: Vec<usize>,
+}
+
+impl Protection {
+    /// Replace every placeholder token in `output` with its original text.
+    pub(crate) fn restore(&self, output: &str) -> String {
+        let mut result = output.to_string();
+        for protected in &self.replacements {
+            result = result.replace(&protected.token, &protected.original);
+        }
+        result
+    }
+
+    /// Map a 1-indexed line number in the protected source back to the original
+    /// source.
+    pub(crate) fn original_line(&self, protected_line: usize) -> usize {
+        if protected_line == 0 {
+            return protected_line;
+        }
+        self.original_lines
+            .get(protected_line - 1)
+            .copied()
+            .unwrap_or(protected_line)
+    }
+}
+
 /// Detect MDX constructs in `source` and replace each with a unique HTML-comment
-/// placeholder, returning the protected source and the replacement map.
+/// placeholder, returning a [`Protection`].
 ///
 /// Returns `None` when there is nothing to protect (the caller then formats the
 /// original source normally).  This is also the do-no-harm fallback: any
 /// construct that cannot be delimited confidently is simply left unprotected
 /// rather than guessed at.
-pub(crate) fn protect(
-    source: &str,
-    comrak_options: &ComrakOptions,
-) -> Option<(String, Vec<Protected>)> {
+pub(crate) fn protect(source: &str, comrak_options: &ComrakOptions) -> Option<Protection> {
     let arena = Arena::new();
     let root = parse_document(&arena, source, comrak_options);
     let line_starts = build_line_starts(source);
@@ -112,34 +146,52 @@ pub(crate) fn protect(
 
     let nonce = choose_nonce(source);
     let mut protected = String::with_capacity(source.len());
-    let mut map = Vec::with_capacity(ranges.len());
+    let mut replacements = Vec::with_capacity(ranges.len());
+    // Line map: `original_lines[n - 1]` is the original line for protected line n.
+    let mut original_lines = vec![1usize];
+    let mut original_line = 1usize;
     let mut cursor = 0;
     for (index, &(start, end)) in ranges.iter().enumerate() {
         // Defensively skip any range that overlaps an already-protected one.
         if start < cursor {
             continue;
         }
-        protected.push_str(&source[cursor..start]);
+        // Copy the prefix verbatim, advancing the line map one entry per newline.
+        let prefix = &source[cursor..start];
+        protected.push_str(prefix);
+        for _ in 0..count_newlines(prefix) {
+            original_line += 1;
+            original_lines.push(original_line);
+        }
+        // The placeholder (no newlines) stays on the current protected line, but
+        // the construct it replaces may span several original lines; account for
+        // those so later lines map back correctly.
         let token = format!("<!--hongdown-mdx:{nonce}:{index}-->");
         protected.push_str(&token);
-        map.push(Protected {
+        original_line += count_newlines(&source[start..end]);
+        replacements.push(Protected {
             token,
             original: source[start..end].to_string(),
         });
         cursor = end;
     }
-    protected.push_str(&source[cursor..]);
+    let tail = &source[cursor..];
+    protected.push_str(tail);
+    for _ in 0..count_newlines(tail) {
+        original_line += 1;
+        original_lines.push(original_line);
+    }
 
-    Some((protected, map))
+    Some(Protection {
+        source: protected,
+        replacements,
+        original_lines,
+    })
 }
 
-/// Replace every placeholder token in `output` with its original text.
-pub(crate) fn restore(output: &str, map: &[Protected]) -> String {
-    let mut result = output.to_string();
-    for protected in map {
-        result = result.replace(&protected.token, &protected.original);
-    }
-    result
+/// Count the `\n` bytes in `text`.
+fn count_newlines(text: &str) -> usize {
+    text.bytes().filter(|&b| b == b'\n').count()
 }
 
 /// Byte offsets of the start of each line in `source` (1-indexed line `n` lives
@@ -1003,7 +1055,7 @@ mod tests {
 
     /// Protect, then assert the round trip restores the original verbatim text
     /// somewhere in the protected source's replacement map.
-    fn protect_source(source: &str) -> Option<(String, Vec<Protected>)> {
+    fn protect_source(source: &str) -> Option<Protection> {
         protect(source, &comrak_options())
     }
 
@@ -1365,10 +1417,10 @@ mod tests {
         assert!(protect_source("Obj {{a:1} / b / /[}]/.source} weird.\n").is_none());
         // A real expression before the ambiguous one is still protected; the
         // inner braces of the ambiguous one are not.
-        let (_, map) =
+        let protection =
             protect_source("Pre {realA} then {{a:1} / b / /[}]/.x} end.\n").expect("realA");
-        assert_eq!(map.len(), 1);
-        assert_eq!(map[0].original, "{realA}");
+        assert_eq!(protection.replacements.len(), 1);
+        assert_eq!(protection.replacements[0].original, "{realA}");
     }
 
     #[test]
@@ -1387,9 +1439,9 @@ mod tests {
     #[test]
     fn protect_records_expression_verbatim() {
         let source = "Hello {user.name}, welcome!\n";
-        let (_, map) = protect_source(source).expect("should protect");
-        assert_eq!(map.len(), 1);
-        assert_eq!(map[0].original, "{user.name}");
+        let protection = protect_source(source).expect("should protect");
+        assert_eq!(protection.replacements.len(), 1);
+        assert_eq!(protection.replacements[0].original, "{user.name}");
     }
 
     #[test]
@@ -1406,20 +1458,36 @@ mod tests {
     #[test]
     fn protect_records_import_verbatim() {
         let source = "import { Chart } from \"./chart.js\";\n\nProse.\n";
-        let (protected, map) = protect_source(source).expect("should protect");
-        assert_eq!(map.len(), 1);
-        assert_eq!(map[0].original, "import { Chart } from \"./chart.js\";");
-        assert!(protected.contains("<!--hongdown-mdx:"));
-        assert!(protected.contains("Prose."));
-        assert!(!protected.contains("import {"));
+        let protection = protect_source(source).expect("should protect");
+        assert_eq!(protection.replacements.len(), 1);
+        assert_eq!(
+            protection.replacements[0].original,
+            "import { Chart } from \"./chart.js\";"
+        );
+        assert!(protection.source.contains("<!--hongdown-mdx:"));
+        assert!(protection.source.contains("Prose."));
+        assert!(!protection.source.contains("import {"));
     }
 
     #[test]
     fn restore_round_trips() {
         let source = "export const meta = { author: 'Hong Minhee' };\n";
-        let (protected, map) = protect_source(source).expect("should protect");
-        let restored = restore(&protected, &map);
+        let protection = protect_source(source).expect("should protect");
+        let restored = protection.restore(&protection.source);
         assert!(restored.contains("export const meta = { author: 'Hong Minhee' };"));
+    }
+
+    #[test]
+    fn original_line_maps_back_across_multiline_construct() {
+        // A 3-line import collapses to a single-line placeholder; lines after it
+        // must map back to their original line numbers.
+        let source = "import {\n  a,\n} from \"x\";\n\nProse line.\n";
+        let protection = protect_source(source).expect("should protect");
+        // "Prose line." is original line 6; in the protected source the import is
+        // one line, so it is on protected line 4.
+        assert_eq!(protection.original_line(4), 6);
+        // Lines within/before the placeholder are unchanged.
+        assert_eq!(protection.original_line(1), 1);
     }
 
     #[test]

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -12,8 +12,8 @@
 //! mangles and replaces each with a unique HTML-comment placeholder, recording
 //! the original text.  comrak emits HTML comments verbatim (as `HtmlBlock` /
 //! `HtmlInline`), so the placeholders survive serialization untouched while the
-//! surrounding Markdown prose is formatted normally.  [`restore`] then swaps the
-//! placeholders back for their original text.
+//! surrounding Markdown prose is formatted normally.  [`Protection::restore`]
+//! then swaps the placeholders back for their original text.
 //!
 //! The detection is AST-guided: only the source spans of `Paragraph` nodes are
 //! scanned.  Content inside fenced/indented code blocks, inline code spans,
@@ -57,6 +57,12 @@ impl Protection {
 
     /// Map a 1-indexed line number in the protected source back to the original
     /// source.
+    ///
+    /// This is exact for block-level constructs (each protected line corresponds
+    /// to one original line).  For the rare case of a multi-line construct
+    /// embedded inline within a paragraph, lines after it on the *same* protected
+    /// line map to the line's start, which can be a few lines early — a minor
+    /// imprecision in warning positions, not in the formatted output.
     pub(crate) fn original_line(&self, protected_line: usize) -> usize {
         if protected_line == 0 {
             return protected_line;
@@ -104,21 +110,24 @@ pub(crate) fn protect(source: &str, comrak_options: &ComrakOptions) -> Option<Pr
         // scanned: code spans and math are emitted verbatim; links/images have
         // their own `[…](…)` bracket/paren structure (a `{…}` in link text would
         // otherwise be protected, desyncing it from its reference definition);
-        // and inline HTML tags (which comrak already preserves) can carry `{…}`
-        // inside a quoted attribute.  Collect their (span-local) ranges to skip.
+        // and a single-line inline HTML tag (which comrak preserves) can carry
+        // `{…}` inside a quoted attribute.  A *multi-line* inline HTML tag is NOT
+        // skipped — comrak does not round-trip it cleanly, so it is left for the
+        // JSX scanner to protect.  Collect the skip ranges (span-local).
         let mut skips: Vec<(usize, usize)> = Vec::new();
         for inner in node.descendants() {
             let (is_owned, inner_sourcepos) = {
                 let data = inner.data.borrow();
-                let is_owned = matches!(
-                    data.value,
+                let pos = data.sourcepos;
+                let is_owned = match data.value {
                     NodeValue::Code(_)
-                        | NodeValue::Math(_)
-                        | NodeValue::Link(_)
-                        | NodeValue::Image(_)
-                        | NodeValue::HtmlInline(_)
-                );
-                (is_owned, data.sourcepos)
+                    | NodeValue::Math(_)
+                    | NodeValue::Link(_)
+                    | NodeValue::Image(_) => true,
+                    NodeValue::HtmlInline(_) => pos.start.line == pos.end.line,
+                    _ => false,
+                };
+                (is_owned, pos)
             };
             if !is_owned {
                 continue;
@@ -1421,6 +1430,20 @@ mod tests {
             protect_source("Pre {realA} then {{a:1} / b / /[}]/.x} end.\n").expect("realA");
         assert_eq!(protection.replacements.len(), 1);
         assert_eq!(protection.replacements[0].original, "{realA}");
+    }
+
+    #[test]
+    fn protect_protects_multiline_opener_without_expression() {
+        // A multi-line opener with no `{…}` attribute is multi-line inline HTML
+        // that comrak does not round-trip, so it must be protected (its
+        // single-line `HtmlInline` skip exclusion does not apply).
+        let source = "<Chart\n  data=\"value\"\n/>\n";
+        let protection = protect_source(source).expect("should protect");
+        assert_eq!(protection.replacements.len(), 1);
+        assert_eq!(
+            protection.replacements[0].original,
+            "<Chart\n  data=\"value\"\n/>"
+        );
     }
 
     #[test]

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -439,7 +439,11 @@ fn scan_esm(span: &str, start: usize) -> Option<usize> {
             b'(' => return None,    // dynamic `import(...)` is an expression, not flow ESM
             _ => needs_from = true, // named / default / namespace import
         }
-    } else if first != b'{' && first != b'*' {
+    } else if first == b'*' {
+        // `export * …` is always a re-export and requires a `from` clause, so
+        // prose such as "export *all* the things" is not mistaken for ESM.
+        needs_from = true;
+    } else if first != b'{' {
         // `export <declaration>`: the word must be a real declaration keyword.
         if !EXPORT_DECLARATIONS.contains(&read_word(span, token)) {
             return None;
@@ -1183,6 +1187,17 @@ mod tests {
     fn scan_esm_rejects_prose_starting_with_export_word() {
         // "export these results from the team" is prose, not an export.
         assert_eq!(scan_esm("export these results from the team.", 0), None);
+    }
+
+    #[test]
+    fn scan_esm_export_star_requires_from() {
+        // `export *` is a re-export and always needs a `from` clause, so prose
+        // using `*` for emphasis is not mistaken for ESM.
+        assert_eq!(scan_esm("export *all* the things.", 0), None);
+        let reexport = "export * from \"./mod.js\";";
+        assert_eq!(scan_esm(reexport, 0), Some(reexport.len()));
+        let reexport_ns = "export * as ns from \"./mod.js\";";
+        assert_eq!(scan_esm(reexport_ns, 0), Some(reexport_ns.len()));
     }
 
     #[test]

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -149,8 +149,9 @@ fn span_bytes(source: &str, line_starts: &[usize], sourcepos: Sourcepos) -> Opti
 /// is left unprotected (a documented limitation) rather than scanning into
 /// unrelated later content.
 ///
-/// Currently detects ESM `import`/`export` statements; JSX elements and `{…}`
-/// expressions are added incrementally.
+/// Detects ESM `import`/`export` statements (recognized at line starts) and JSX
+/// elements/fragments (recognized anywhere).  `{…}` expressions are added
+/// incrementally.
 fn find_constructs(span: &str) -> Vec<(usize, usize)> {
     let bytes = span.as_bytes();
     let mut ranges = Vec::new();
@@ -171,6 +172,15 @@ fn find_constructs(span: &str) -> Vec<(usize, usize)> {
                 at_line_start = bytes.get(index) == Some(&b'\n');
                 continue;
             }
+        }
+        // JSX elements and fragments can appear anywhere (flow or inline).
+        if bytes[index] == b'<'
+            && let Some(end) = scan_jsx(span, index)
+        {
+            ranges.push((index, end));
+            index = end;
+            at_line_start = bytes.get(index) == Some(&b'\n');
+            continue;
         }
         if bytes[index] == b'\n' {
             at_line_start = true;
@@ -295,25 +305,8 @@ fn scan_esm(span: &str, start: usize) -> Option<usize> {
             b'"' | b'\'' | b'`' => {
                 index = skip_string(span, index)?;
             }
-            b'/' if bytes.get(index + 1) == Some(&b'/') => {
-                // Line comment: skip to (but not past) the end of the line so the
-                // newline arm still sees it for the depth check.
-                index += 2;
-                while index < span.len() && bytes[index] != b'\n' {
-                    index += char_len(bytes[index]);
-                }
-            }
-            b'/' if bytes.get(index + 1) == Some(&b'*') => {
-                // Block comment: skip to the closing `*/`.
-                index += 2;
-                while index < span.len()
-                    && !(bytes[index] == b'*' && bytes.get(index + 1) == Some(&b'/'))
-                {
-                    index += char_len(bytes[index]);
-                }
-                if index < span.len() {
-                    index += 2;
-                }
+            b'/' if let Some(after) = skip_comment(span, index) => {
+                index = after;
             }
             b'{' | b'(' | b'[' => {
                 depth += 1;
@@ -361,6 +354,256 @@ fn finish_esm(end: usize, needs_from: bool, saw_from: bool) -> Option<usize> {
     } else {
         Some(end)
     }
+}
+
+/// If a `//` line comment or `/* … */` block comment starts at `start`, return
+/// the byte offset just past it.  A line comment stops at — but does not consume
+/// — the terminating newline.  Returns `None` when no comment starts there.
+fn skip_comment(span: &str, start: usize) -> Option<usize> {
+    let bytes = span.as_bytes();
+    match (bytes.get(start), bytes.get(start + 1)) {
+        (Some(b'/'), Some(b'/')) => {
+            let mut index = start + 2;
+            while index < span.len() && bytes[index] != b'\n' {
+                index += char_len(bytes[index]);
+            }
+            Some(index)
+        }
+        (Some(b'/'), Some(b'*')) => {
+            let mut index = start + 2;
+            while index < span.len()
+                && !(bytes[index] == b'*' && bytes.get(index + 1) == Some(&b'/'))
+            {
+                index += char_len(bytes[index]);
+            }
+            if index < span.len() {
+                index += 2; // consume the closing `*/`
+            }
+            Some(index)
+        }
+        _ => None,
+    }
+}
+
+/// Whether `byte` can appear in a JSX tag or component name (after the first
+/// letter): identifiers, member access (`Foo.Bar`), and hyphenated custom
+/// element names.
+fn is_tag_name_byte(byte: u8) -> bool {
+    byte.is_ascii_alphanumeric() || matches!(byte, b'.' | b'-' | b'_' | b'$')
+}
+
+/// A parsed JSX opening tag (or fragment opener `<>`).
+struct OpenTag<'a> {
+    /// Byte offset just past the tag's closing `>` or `/>`.
+    end: usize,
+    /// The tag/component name (empty for a fragment).
+    name: &'a str,
+    /// Whether the tag is self-closing (`/>`).
+    self_closing: bool,
+    /// Whether this is a fragment opener `<>`.
+    is_fragment: bool,
+    /// Whether the tag carries a `{…}` expression attribute.
+    has_expression: bool,
+    /// Whether the tag spans more than one line.
+    multiline: bool,
+}
+
+/// Parse a JSX opening tag (or fragment `<>`) starting at `start` (a `<`).
+/// String literals and `{…}` expression attributes are skipped so that
+/// `>`/`{`/`}` inside them do not terminate the tag.  Returns `None` if the tag
+/// is not well-formed within the span.
+fn scan_open_tag(span: &str, start: usize) -> Option<OpenTag<'_>> {
+    let bytes = span.as_bytes();
+    // Fragment opener `<>`.
+    if bytes.get(start + 1) == Some(&b'>') {
+        return Some(OpenTag {
+            end: start + 2,
+            name: "",
+            self_closing: false,
+            is_fragment: true,
+            has_expression: false,
+            multiline: false,
+        });
+    }
+    // A tag name must begin with a letter.
+    if !bytes.get(start + 1).is_some_and(u8::is_ascii_alphabetic) {
+        return None;
+    }
+    let name_start = start + 1;
+    let mut index = name_start;
+    while index < span.len() && is_tag_name_byte(bytes[index]) {
+        index += 1;
+    }
+    let name = &span[name_start..index];
+
+    let mut has_expression = false;
+    let mut multiline = false;
+    while index < span.len() {
+        match bytes[index] {
+            b'>' => {
+                return Some(OpenTag {
+                    end: index + 1,
+                    name,
+                    self_closing: false,
+                    is_fragment: false,
+                    has_expression,
+                    multiline,
+                });
+            }
+            b'/' if bytes.get(index + 1) == Some(&b'>') => {
+                return Some(OpenTag {
+                    end: index + 2,
+                    name,
+                    self_closing: true,
+                    is_fragment: false,
+                    has_expression,
+                    multiline,
+                });
+            }
+            b'{' => {
+                has_expression = true;
+                index = skip_braces(span, index)?;
+            }
+            b'"' | b'\'' | b'`' => {
+                index = skip_string(span, index)?;
+            }
+            b'\n' => {
+                multiline = true;
+                index += 1;
+            }
+            byte => index += char_len(byte),
+        }
+    }
+    None
+}
+
+/// Read a JSX closing tag `</name>` (or fragment close `</>`) starting at `start`
+/// (a `<` followed by `/`).  Returns the tag name (empty for a fragment) and the
+/// byte offset just past the `>`.
+fn read_close_tag(span: &str, start: usize) -> Option<(&str, usize)> {
+    let bytes = span.as_bytes();
+    let mut index = start + 2;
+    let name_start = index;
+    while index < span.len() && is_tag_name_byte(bytes[index]) {
+        index += 1;
+    }
+    let name = &span[name_start..index];
+    while index < span.len() && matches!(bytes[index], b' ' | b'\t' | b'\n') {
+        index += 1;
+    }
+    if bytes.get(index) != Some(&b'>') {
+        return None;
+    }
+    Some((name, index + 1))
+}
+
+/// Skip a balanced `{…}` expression starting at `start` (a `{`).  Returns the
+/// byte offset just past the matching `}`.  String literals and comments inside
+/// are skipped so their braces do not affect nesting.  Returns `None` if the
+/// braces never balance within the span.
+fn skip_braces(span: &str, start: usize) -> Option<usize> {
+    let bytes = span.as_bytes();
+    let mut depth = 0i32;
+    let mut index = start;
+    while index < span.len() {
+        match bytes[index] {
+            b'{' => {
+                depth += 1;
+                index += 1;
+            }
+            b'}' => {
+                depth -= 1;
+                index += 1;
+                if depth == 0 {
+                    return Some(index);
+                }
+            }
+            b'"' | b'\'' | b'`' => {
+                index = skip_string(span, index)?;
+            }
+            b'/' if let Some(after) = skip_comment(span, index) => {
+                index = after;
+            }
+            byte => index += char_len(byte),
+        }
+    }
+    None
+}
+
+/// If a JSX element or fragment that comrak would otherwise corrupt starts at
+/// `start` (a `<`), return the byte offset just past its end.
+///
+/// A construct is protected only when comrak misparses it: a fragment (`<>…</>`),
+/// or an element whose opening tag carries a `{…}` expression attribute or spans
+/// multiple lines.  A plain single-line HTML-shaped tag (e.g. `<Chart x="y" />`)
+/// is already preserved verbatim by comrak, so it is left untouched (returns
+/// `None`).  Autolinks (`<https://…>`) and stray `<` in prose also return `None`.
+///
+/// Container elements are protected as a whole (opening tag through the matching
+/// closing tag), consistent with comrak's existing treatment of tag-based JSX;
+/// the embedded JSX is preserved rather than reformatted.  String literals and
+/// `{…}` expressions (which may themselves contain `<`/`>`) are skipped while
+/// matching tags.  Returns `None` for anything that cannot be delimited as a
+/// balanced construct within the span (do-no-harm).
+fn scan_jsx(span: &str, start: usize) -> Option<usize> {
+    let bytes = span.as_bytes();
+    // Must be able to begin a JSX construct: `<>` or `<` + tag name.
+    match bytes.get(start + 1) {
+        Some(b'>') => {}
+        Some(&byte) if byte.is_ascii_alphabetic() => {}
+        _ => return None,
+    }
+
+    // The protection decision depends only on the *root* construct: comrak
+    // corrupts a fragment, or a tag with a `{…}` attribute or multi-line opener.
+    // A plain root tag (even a container) is preserved by comrak as-is, so it is
+    // left alone — the caller then scans its children, where any nested
+    // expression/JSX is protected independently and prose stays formatted.
+    let root = scan_open_tag(span, start)?;
+    if !(root.is_fragment || root.has_expression || root.multiline) {
+        return None;
+    }
+    if root.self_closing {
+        return Some(root.end);
+    }
+
+    // Protected container: scan to the matching closing tag, tracking nesting.
+    // Nested tags' own attributes do not affect the (already decided) protection.
+    let mut stack: Vec<&str> = vec![root.name];
+    let mut index = root.end;
+    while index < span.len() {
+        match bytes[index] {
+            b'<' if bytes.get(index + 1) == Some(&b'/') => {
+                let (name, after) = read_close_tag(span, index)?;
+                match stack.pop() {
+                    Some(open) if open == name => {}
+                    _ => return None, // mismatched or stray close tag
+                }
+                index = after;
+                if stack.is_empty() {
+                    return Some(index);
+                }
+            }
+            b'<' if matches!(bytes.get(index + 1), Some(b'>'))
+                || bytes
+                    .get(index + 1)
+                    .is_some_and(|b| b.is_ascii_alphabetic()) =>
+            {
+                let tag = scan_open_tag(span, index)?;
+                index = tag.end;
+                if !tag.self_closing {
+                    stack.push(tag.name);
+                }
+            }
+            b'<' => index += 1, // a literal `<` in element children
+            b'{' => {
+                // A `{…}` expression among element children.
+                index = skip_braces(span, index)?;
+            }
+            byte => index += char_len(byte),
+        }
+    }
+    None
 }
 
 /// Skip a string literal that starts at `start` (a `"`, `'`, or `` ` `` quote).
@@ -543,6 +786,101 @@ mod tests {
         // protected.
         assert!(protect_source("export these notes from class today.\n").is_none());
         assert!(protect_source("import more discipline into your life.\n").is_none());
+    }
+
+    #[test]
+    fn scan_jsx_self_closing_with_expression_attr() {
+        let span = "<Chart data={data} />";
+        assert_eq!(scan_jsx(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_jsx_plain_self_closing_not_protected() {
+        // A complete single-line tag is already preserved verbatim by comrak.
+        assert_eq!(scan_jsx("<Chart data=\"x\" />", 0), None);
+    }
+
+    #[test]
+    fn scan_jsx_multiline_self_closing() {
+        let span = "<PackageManagerTabs\n  command={{ npm: \"x\" }}\n/>";
+        assert_eq!(scan_jsx(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_jsx_multiline_open_tag_without_expression() {
+        let span = "<Chart\n  data=\"x\"\n/>";
+        assert_eq!(scan_jsx(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_jsx_fragment() {
+        let span = "<>hello</>";
+        assert_eq!(scan_jsx(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_jsx_container_with_expression_attr() {
+        let span = "<Tabs value={selected}>content</Tabs>";
+        assert_eq!(scan_jsx(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_jsx_plain_container_not_protected() {
+        // comrak preserves the tags; any expression children are handled
+        // separately by the expression scanner.
+        assert_eq!(scan_jsx("<Tabs>content</Tabs>", 0), None);
+    }
+
+    #[test]
+    fn scan_jsx_plain_container_with_braced_child_not_protected() {
+        // The root tag is plain, so the whole container is not protected even
+        // though a child has an expression attribute — the child is protected
+        // separately and the prose between tags stays formattable.
+        assert_eq!(scan_jsx("<Note>x <Badge count={n} /></Note>", 0), None);
+    }
+
+    #[test]
+    fn scan_jsx_double_brace_attribute() {
+        let span = "<Foo style={{ color: \"red\" }} />";
+        assert_eq!(scan_jsx(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_jsx_nested_self_closing_in_braced_container() {
+        let span = "<Foo bar={1}><Baz/></Foo>";
+        assert_eq!(scan_jsx(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_jsx_expression_attribute_with_angle_brackets() {
+        // The `<Bar/>` lives inside an attribute expression; the element is
+        // protected as a whole via its `{…}` attribute.
+        let span = "<Foo render={() => <Bar/>} />";
+        assert_eq!(scan_jsx(span, 0), Some(span.len()));
+    }
+
+    #[test]
+    fn scan_jsx_attribute_string_with_angle_and_brace_not_protected() {
+        // `>` and `{` live in a quoted attribute, so comrak parses the tag fine.
+        assert_eq!(scan_jsx("<Foo title=\"a > b {c}\" />", 0), None);
+    }
+
+    #[test]
+    fn scan_jsx_rejects_comparison_and_non_tag() {
+        assert_eq!(scan_jsx("< b", 0), None);
+        assert_eq!(scan_jsx("<3 ideas", 0), None);
+        assert_eq!(scan_jsx("</close>", 0), None);
+    }
+
+    #[test]
+    fn scan_jsx_rejects_autolink() {
+        assert_eq!(scan_jsx("<https://example.com>", 0), None);
+        assert_eq!(scan_jsx("<user@example.com>", 0), None);
+    }
+
+    #[test]
+    fn scan_jsx_unterminated_returns_none() {
+        assert_eq!(scan_jsx("<Foo bar={1}>no close", 0), None);
     }
 
     #[test]

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -714,7 +714,7 @@ fn read_close_tag(span: &str, start: usize) -> Option<(&str, usize)> {
         index += 1;
     }
     let name = &span[name_start..index];
-    while index < span.len() && matches!(bytes[index], b' ' | b'\t' | b'\n') {
+    while index < span.len() && matches!(bytes[index], b' ' | b'\t' | b'\n' | b'\r') {
         index += 1;
     }
     if bytes.get(index) != Some(&b'>') {
@@ -1354,6 +1354,15 @@ mod tests {
     fn scan_jsx_fragment() {
         let span = "<>hello</>";
         assert_eq!(jsx_end(span), Some(span.len()));
+    }
+
+    #[test]
+    fn read_close_tag_skips_whitespace_including_carriage_return() {
+        // A CRLF (or any whitespace) between the name and `>` is skipped.
+        let span = "</Foo\r\n>";
+        assert_eq!(read_close_tag(span, 0), Some(("Foo", span.len())));
+        // Fragment close `</>`.
+        assert_eq!(read_close_tag("</>", 0), Some(("", "</>".len())));
     }
 
     #[test]

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -277,9 +277,13 @@ impl<'a> Serializer<'a> {
             }
 
             if let NodeValue::HtmlBlock(html_block) = &child.data.borrow().value {
-                // Add a blank line before the first trailing HTML block
+                // Add a blank line before the first trailing HTML block, but only
+                // when something precedes it — a document whose only content is
+                // HTML blocks must not gain leading blank lines.
                 if is_first {
-                    if !self.output.ends_with("\n\n") {
+                    if self.output.is_empty() {
+                        // Nothing precedes this block; no separator needed.
+                    } else if !self.output.ends_with("\n\n") {
                         if self.output.ends_with('\n') {
                             self.output.push('\n');
                         } else {

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -271,16 +271,19 @@ impl<'a> Serializer<'a> {
         start_index: usize,
     ) {
         let mut is_first = true;
+        let mut prev_end_line = 0usize;
         for (i, child) in children.iter().enumerate() {
             if i < start_index {
                 continue;
             }
 
-            if let NodeValue::HtmlBlock(html_block) = &child.data.borrow().value {
-                // Add a blank line before the first trailing HTML block, but only
-                // when something precedes it — a document whose only content is
-                // HTML blocks must not gain leading blank lines.
+            let data = child.data.borrow();
+            if let NodeValue::HtmlBlock(html_block) = &data.value {
+                let sourcepos = data.sourcepos;
                 if is_first {
+                    // Add a blank line before the first trailing HTML block, but
+                    // only when something precedes it — a document whose only
+                    // content is HTML blocks must not gain leading blank lines.
                     if self.output.is_empty() {
                         // Nothing precedes this block; no separator needed.
                     } else if !self.output.ends_with("\n\n") {
@@ -291,7 +294,16 @@ impl<'a> Serializer<'a> {
                         }
                     }
                     is_first = false;
+                } else if sourcepos.start.line > prev_end_line + 1 {
+                    // Preserve a blank line that separated two HTML blocks in the
+                    // source (otherwise consecutive comments/placeholders would be
+                    // concatenated without their original separation).
+                    if !self.output.ends_with('\n') {
+                        self.output.push('\n');
+                    }
+                    self.output.push('\n');
                 }
+                prev_end_line = sourcepos.end.line;
                 self.output.push_str(&html_block.literal);
             }
         }

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -294,14 +294,16 @@ impl<'a> Serializer<'a> {
                         }
                     }
                     is_first = false;
-                } else if sourcepos.start.line > prev_end_line + 1 {
+                } else if sourcepos.start.line > prev_end_line + 1 && !self.output.ends_with("\n\n")
+                {
                     // Preserve a blank line that separated two HTML blocks in the
                     // source (otherwise consecutive comments/placeholders would be
                     // concatenated without their original separation).
-                    if !self.output.ends_with('\n') {
+                    if self.output.ends_with('\n') {
                         self.output.push('\n');
+                    } else {
+                        self.output.push_str("\n\n");
                     }
-                    self.output.push('\n');
                 }
                 prev_end_line = sourcepos.end.line;
                 self.output.push_str(&html_block.literal);

--- a/src/serializer/formatter.rs
+++ b/src/serializer/formatter.rs
@@ -95,11 +95,22 @@ pub fn run_formatter(
         .spawn()
         .map_err(FormatterError::Spawn)?;
 
-    // Write code to stdin
+    // Write code to stdin. A formatter may reject its input and exit before
+    // draining stdin, which makes this write fail with a broken pipe. That is
+    // not necessarily a real stdin failure: if the process then exits non-zero,
+    // its exit status is the meaningful error. Defer the decision until the exit
+    // status is known rather than masking it here. A broken pipe on an otherwise
+    // *successful* exit is still treated as an error below, so a process that
+    // closes stdin early is never trusted to have produced complete output.
+    let mut stdin_broken_pipe: Option<std::io::Error> = None;
     if let Some(mut stdin) = child.stdin.take() {
-        stdin
-            .write_all(code.as_bytes())
-            .map_err(FormatterError::Stdin)?;
+        match stdin.write_all(code.as_bytes()) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {
+                stdin_broken_pipe = Some(e);
+            }
+            Err(e) => return Err(FormatterError::Stdin(e)),
+        }
         // stdin is dropped here, closing it
     }
 
@@ -113,14 +124,20 @@ pub fn run_formatter(
             Ok(Some(status)) => {
                 // Process finished
                 let output = child.wait_with_output().map_err(FormatterError::Spawn)?;
-                if status.success() {
-                    return String::from_utf8(output.stdout).map_err(FormatterError::InvalidUtf8);
-                } else {
+                if !status.success() {
                     return Err(FormatterError::NonZeroExit {
                         code: status.code(),
                         stderr: String::from_utf8_lossy(&output.stderr).to_string(),
                     });
                 }
+                // The process succeeded. If it closed stdin before we could
+                // deliver all of the input, its output may be based on truncated
+                // input, so surface the broken pipe rather than replacing the
+                // code block with that untrustworthy (possibly empty) output.
+                if let Some(e) = stdin_broken_pipe.take() {
+                    return Err(FormatterError::Stdin(e));
+                }
+                return String::from_utf8(output.stdout).map_err(FormatterError::InvalidUtf8);
             }
             Ok(None) => {
                 // Still running
@@ -168,6 +185,31 @@ mod tests {
         // false always exits with code 1
         let result = run_formatter(&["false".to_string()], "code", 5);
         assert!(matches!(result, Err(FormatterError::NonZeroExit { .. })));
+    }
+
+    #[test]
+    fn test_run_formatter_nonzero_exit_large_stdin() {
+        // `false` exits non-zero without reading stdin. A 1 MiB payload far
+        // exceeds the OS pipe buffer (64 KiB or less on Linux, macOS, and
+        // Windows), so the write hits a broken pipe once the child's read end
+        // closes. That must not be reported as a stdin error, because the
+        // process's non-zero exit is the meaningful result. This reliably
+        // exercises the broken-pipe path that the small-input
+        // `test_run_formatter_nonzero_exit` reaches only intermittently.
+        let code = "x".repeat(1024 * 1024);
+        let result = run_formatter(&["false".to_string()], &code, 5);
+        assert!(matches!(result, Err(FormatterError::NonZeroExit { .. })));
+    }
+
+    #[test]
+    fn test_run_formatter_success_without_consuming_stdin_errors() {
+        // `true` exits zero without reading stdin, so a large payload triggers a
+        // broken pipe on a successful exit. The output (here empty) must not be
+        // trusted to replace the code block; the broken pipe is surfaced as an
+        // error so the caller keeps the original code instead of erasing it.
+        let code = "x".repeat(1024 * 1024);
+        let result = run_formatter(&["true".to_string()], &code, 5);
+        assert!(matches!(result, Err(FormatterError::Stdin(_))));
     }
 
     #[test]

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -2645,6 +2645,20 @@ fn test_leading_html_comment_block_then_content() {
 }
 
 #[test]
+fn test_blank_line_preserved_between_trailing_html_comments() {
+    // Two HTML comments separated by a blank line must keep that separation
+    // rather than being concatenated onto adjacent lines.
+    let result = parse_and_serialize_with_source("<!-- a -->\n\n<!-- b -->\n");
+    assert_eq!(result, "<!-- a -->\n\n<!-- b -->\n");
+}
+
+#[test]
+fn test_adjacent_trailing_html_comments_stay_adjacent() {
+    let result = parse_and_serialize_with_source("<!-- a -->\n<!-- b -->\n");
+    assert_eq!(result, "<!-- a -->\n<!-- b -->\n");
+}
+
+#[test]
 fn test_trailing_html_comment_after_references() {
     // Trailing HTML comments (like cSpell ignore directives) should remain
     // at the end of the document after reference definitions.

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -2629,6 +2629,22 @@ fn test_shortcut_link_followed_by_footnote() {
 }
 
 #[test]
+fn test_sole_html_comment_has_no_leading_blank_lines() {
+    // A document whose only content is an HTML comment must not gain leading
+    // blank lines: it is a "trailing" HTML block with nothing preceding it.
+    let result = parse_and_serialize_with_source("<!-- hi -->\n");
+    assert_eq!(result, "<!-- hi -->\n");
+}
+
+#[test]
+fn test_leading_html_comment_block_then_content() {
+    // An HTML comment that opens the document (followed by prose) keeps its
+    // position with no spurious leading blank lines.
+    let result = parse_and_serialize_with_source("<!-- hi -->\n\nText.\n");
+    assert_eq!(result, "<!-- hi -->\n\nText.\n");
+}
+
+#[test]
 fn test_trailing_html_comment_after_references() {
     // Trailing HTML comments (like cSpell ignore directives) should remain
     // at the end of the document after reference definitions.

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -35,6 +35,10 @@ pub struct JsOptions {
     /// Recognize and preserve TeX/LaTeX math expressions (default: true).
     pub math: Option<bool>,
 
+    /// Enable MDX mode: preserve embedded JavaScript/JSX verbatim (default:
+    /// false).
+    pub mdx: Option<bool>,
+
     /// Use setext-style for h1 headings (default: true).
     pub setext_h1: Option<bool>,
 
@@ -154,6 +158,9 @@ impl JsOptions {
         }
         if let Some(v) = self.math {
             opts.math = v;
+        }
+        if let Some(v) = self.mdx {
+            opts.mdx = v;
         }
         if let Some(v) = self.setext_h1 {
             opts.setext_h1 = v;
@@ -389,7 +396,18 @@ pub fn format_with_code_formatter(
     comrak_options.extension.tasklist = true;
     comrak_options.extension.math_dollars = opts.math;
 
-    let root = parse_document(&arena, input, &comrak_options);
+    // In MDX mode, protect embedded JavaScript/JSX before parsing and restore it
+    // afterwards (see [`crate::mdx`]).
+    let (source, restore_map) = if opts.mdx {
+        match crate::mdx::protect(input, &comrak_options) {
+            Some((protected, map)) => (std::borrow::Cow::Owned(protected), Some(map)),
+            None => (std::borrow::Cow::Borrowed(input), None),
+        }
+    } else {
+        (std::borrow::Cow::Borrowed(input), None)
+    };
+
+    let root = parse_document(&arena, &source, &comrak_options);
 
     // Create callback closure if provided
     let callback: crate::serializer::CodeFormatterCallback = code_formatter.map(|func| {
@@ -412,10 +430,15 @@ pub fn format_with_code_formatter(
     });
 
     let result =
-        crate::serializer::serialize_with_code_formatter(root, &opts, Some(input), callback);
+        crate::serializer::serialize_with_code_formatter(root, &opts, Some(&source), callback);
+
+    let output = match &restore_map {
+        Some(map) => crate::mdx::restore(&result.output, map),
+        None => result.output,
+    };
 
     let js_result = JsFormatResult {
-        output: result.output,
+        output,
         warnings: result
             .warnings
             .into_iter()

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -398,16 +398,14 @@ pub fn format_with_code_formatter(
 
     // In MDX mode, protect embedded JavaScript/JSX before parsing and restore it
     // afterwards (see [`crate::mdx`]).
-    let (source, restore_map) = if opts.mdx {
-        match crate::mdx::protect(input, &comrak_options) {
-            Some((protected, map)) => (std::borrow::Cow::Owned(protected), Some(map)),
-            None => (std::borrow::Cow::Borrowed(input), None),
-        }
+    let protection = if opts.mdx {
+        crate::mdx::protect(input, &comrak_options)
     } else {
-        (std::borrow::Cow::Borrowed(input), None)
+        None
     };
+    let source: &str = protection.as_ref().map_or(input, |p| p.source.as_str());
 
-    let root = parse_document(&arena, &source, &comrak_options);
+    let root = parse_document(&arena, source, &comrak_options);
 
     // Create callback closure if provided
     let callback: crate::serializer::CodeFormatterCallback = code_formatter.map(|func| {
@@ -430,10 +428,10 @@ pub fn format_with_code_formatter(
     });
 
     let result =
-        crate::serializer::serialize_with_code_formatter(root, &opts, Some(&source), callback);
+        crate::serializer::serialize_with_code_formatter(root, &opts, Some(source), callback);
 
-    let output = match &restore_map {
-        Some(map) => crate::mdx::restore(&result.output, map),
+    let output = match &protection {
+        Some(p) => p.restore(&result.output),
         None => result.output,
     };
 
@@ -443,7 +441,10 @@ pub fn format_with_code_formatter(
             .warnings
             .into_iter()
             .map(|w| JsWarning {
-                line: w.line,
+                // Map protected-source line numbers back to the original.
+                line: protection
+                    .as_ref()
+                    .map_or(w.line, |p| p.original_line(w.line)),
                 message: w.message,
             })
             .collect(),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -981,6 +981,77 @@ mod cli_tests {
         assert_eq!(exit_code, 0, "All files should pass check");
         assert!(stdout.is_empty());
     }
+
+    /// A `.mdx` file passed on the command line enables MDX mode automatically,
+    /// preserving embedded JavaScript verbatim.
+    #[test]
+    fn test_mdx_file_enables_mdx_mode() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let mdx_file = temp_dir.path().join("example.mdx");
+        fs::write(&mdx_file, "import { Chart } from \"./chart.js\";\n")
+            .expect("Failed to write example.mdx");
+
+        let (stdout, _stderr, exit_code) = run_hongdown(&[mdx_file.to_str().unwrap()], None);
+        assert_eq!(exit_code, 0);
+        assert!(
+            stdout.contains("import { Chart } from \"./chart.js\";"),
+            "expected the import to be preserved for a .mdx file: {stdout:?}"
+        );
+    }
+
+    /// A `.md` file with the same content is NOT MDX-protected by default (its
+    /// quotes are curled), confirming auto-detection is extension-specific.
+    #[test]
+    fn test_md_file_does_not_enable_mdx_mode() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let md_file = temp_dir.path().join("example.md");
+        fs::write(&md_file, "import { Chart } from \"./chart.js\";\n")
+            .expect("Failed to write example.md");
+
+        let (stdout, _stderr, exit_code) = run_hongdown(&[md_file.to_str().unwrap()], None);
+        assert_eq!(exit_code, 0);
+        assert!(
+            stdout.contains('\u{201c}'),
+            "expected curly quotes for a .md file without --mdx: {stdout:?}"
+        );
+    }
+
+    /// The `--mdx` flag enables MDX mode for a `.md` file (and for stdin).
+    #[test]
+    fn test_mdx_flag_enables_mdx_mode_for_md() {
+        use std::fs;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().expect("Failed to create temp dir");
+        let md_file = temp_dir.path().join("example.md");
+        fs::write(&md_file, "import { Chart } from \"./chart.js\";\n")
+            .expect("Failed to write example.md");
+
+        let (stdout, _stderr, exit_code) =
+            run_hongdown(&["--mdx", md_file.to_str().unwrap()], None);
+        assert_eq!(exit_code, 0);
+        assert!(
+            stdout.contains("import { Chart } from \"./chart.js\";"),
+            "expected --mdx to preserve the import: {stdout:?}"
+        );
+    }
+
+    /// `--mdx` also applies to stdin input.
+    #[test]
+    fn test_mdx_flag_applies_to_stdin() {
+        let (stdout, _stderr, exit_code) = run_hongdown(
+            &["--mdx", "--stdin"],
+            Some("export const meta = { author: 'Hong Minhee' };\n"),
+        );
+        assert_eq!(exit_code, 0);
+        assert!(stdout.contains("export const meta = { author: 'Hong Minhee' };"));
+    }
 }
 
 /// Test proper nouns directive in sentence case.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -315,12 +315,33 @@ mod mdx_jsx {
         );
     }
 
-    /// A container element with an expression attribute is preserved as a whole.
+    /// A container whose opening tag comrak cannot parse (here a `{{…}}` object
+    /// attribute, which breaks CommonMark's tag grammar) is preserved as a whole,
+    /// keeping its children verbatim.
     #[test]
-    fn braced_container_preserved() {
-        let input = "<Tabs value={selected}>It's \"nested\" content</Tabs>\n";
+    fn corrupt_braced_container_preserved() {
+        let input = "<Tabs value={{ id: selected }}>It's \"nested\" content</Tabs>\n";
+        let off = format(input, &Options::default()).unwrap();
+        assert!(
+            off.contains('\u{201c}'),
+            "expected corruption when off: {off:?}"
+        );
         let on = format(input, &mdx_options()).unwrap();
         assert_eq!(on, input);
+    }
+
+    /// A container whose opening tag *is* valid inline HTML (a simple `{…}`
+    /// attribute) is handled by comrak: the JS attribute is preserved while the
+    /// Markdown children are still formatted.
+    #[test]
+    fn simple_braced_container_keeps_attribute_formats_children() {
+        let input = "<Tabs value={selected}>It's \"nested\" content</Tabs>\n";
+        let on = format(input, &mdx_options()).unwrap();
+        assert!(
+            on.contains("value={selected}"),
+            "JS attribute preserved: {on:?}"
+        );
+        assert!(on.contains('\u{201c}'), "children formatted: {on:?}");
     }
 
     /// A plain (brace-free, single-line) tag is handled by comrak already, so MDX
@@ -378,6 +399,176 @@ mod mdx_jsx {
         let on = format(input, &mdx_options()).unwrap();
         let off = format(input, &Options::default()).unwrap();
         assert_eq!(on, off);
+    }
+}
+
+/// MDX mode: bare `{…}` expressions are preserved verbatim, including their
+/// comments and string literals, while surrounding prose is still formatted.
+mod mdx_expressions {
+    use hongdown::{Options, format};
+
+    fn mdx_options() -> Options {
+        Options {
+            mdx: true,
+            ..Options::default()
+        }
+    }
+
+    /// A bare flow expression `{/* … */}` is corrupted without MDX mode (escaped
+    /// `*`, curled quotes) and preserved with it.
+    #[test]
+    fn flow_comment_expression() {
+        let input = "{/* a JSX comment with \"quotes\" */}\n";
+        let off = format(input, &Options::default()).unwrap();
+        assert_ne!(off, input, "expected corruption when off");
+        let on = format(input, &mdx_options()).unwrap();
+        assert_eq!(on, input);
+    }
+
+    /// An inline expression in prose is preserved while the prose is formatted.
+    #[test]
+    fn inline_expression_in_prose() {
+        let input = "Total: {count} items in the \"cart\".\n";
+        let on = format(input, &mdx_options()).unwrap();
+        assert!(on.contains("{count}"));
+        assert!(on.contains('\u{201c}'), "prose quotes should curl: {on:?}");
+    }
+
+    /// An expression's own string literal keeps straight quotes.
+    #[test]
+    fn expression_string_preserved() {
+        let input = "Price is {formatCurrency(\"USD\", 5)} today.\n";
+        let off = format(input, &Options::default()).unwrap();
+        assert!(off.contains('\u{201c}'), "expected corruption when off");
+        let on = format(input, &mdx_options()).unwrap();
+        assert_eq!(on, input);
+    }
+
+    /// A `{#id}` heading anchor is not treated as an expression; the heading is
+    /// formatted normally.
+    #[test]
+    fn heading_anchor_not_protected() {
+        let input = "## Heading title {#my-id}\n";
+        let on = format(input, &mdx_options()).unwrap();
+        let off = format(input, &Options::default()).unwrap();
+        assert_eq!(on, off);
+    }
+
+    /// Braces inside inline code and math are not mistaken for expressions.
+    #[test]
+    fn braces_in_code_and_math_untouched() {
+        let code = "Use `{x}` inline.\n";
+        let math = "The value $\\frac{1}{2}$ is a half.\n";
+        for input in [code, math] {
+            let on = format(input, &mdx_options()).unwrap();
+            let off = format(input, &Options::default()).unwrap();
+            assert_eq!(
+                on, off,
+                "code/math braces should be left to comrak: {input:?}"
+            );
+        }
+    }
+
+    /// Braces inside Markdown link/image syntax (text or destination) are owned
+    /// by comrak, so MDX mode leaves them alone and stays idempotent — a `{…}`
+    /// in link text must not desync from its reference definition.
+    #[test]
+    fn braces_in_links_untouched() {
+        let cases = [
+            "See [user](https://example.com/{id}) here.\n",
+            "Link [{label}](https://example.com/) text.\n",
+            "Image ![alt](https://example.com/{file}.png) here.\n",
+        ];
+        for input in cases {
+            let on = format(input, &mdx_options()).unwrap();
+            let off = format(input, &Options::default()).unwrap();
+            assert_eq!(
+                on, off,
+                "link/image braces should be left to comrak: {input:?}"
+            );
+            assert_eq!(
+                on,
+                format(&on, &mdx_options()).unwrap(),
+                "should be idempotent: {input:?}"
+            );
+        }
+    }
+
+    /// A real expression alongside a link is still protected.
+    #[test]
+    fn expression_next_to_link_still_protected() {
+        let input = "Mixed [{label}](u) and a real {expr} here.\n";
+        let on = format(input, &mdx_options()).unwrap();
+        assert!(on.contains("{expr}"));
+        assert!(on.contains("[{label}](u)"));
+        assert_eq!(on, format(&on, &mdx_options()).unwrap());
+    }
+
+    /// An expression containing a regex literal whose character class holds a
+    /// `}` is preserved as a whole (the regex brace must not end the expression).
+    #[test]
+    fn expression_with_regex_brace() {
+        let input = "Result: {value.replace(/[}]/g, \"x\")} done.\n";
+        let off = format(input, &Options::default()).unwrap();
+        assert!(
+            off.contains('\u{201c}'),
+            "expected corruption when off: {off:?}"
+        );
+        let on = format(input, &mdx_options()).unwrap();
+        assert_eq!(on, input);
+    }
+
+    /// Division inside an expression is not mistaken for a regex literal.
+    #[test]
+    fn expression_with_division_is_idempotent() {
+        let input = "Ratio: {a / b} and {c / d}.\n";
+        let on = format(input, &mdx_options()).unwrap();
+        assert!(on.contains("{a / b}"));
+        assert_eq!(on, format(&on, &mdx_options()).unwrap());
+    }
+}
+
+/// MDX mode end to end: the full reproduction from the issue round-trips
+/// byte-for-byte and is idempotent.
+mod mdx_document {
+    use hongdown::{Options, format};
+
+    #[test]
+    fn issue_reproduction_preserved_and_idempotent() {
+        let input = "import { Chart } from \"./chart.js\";\n\n\
+            export const meta = { author: 'Hong Minhee' };\n\n\
+            <PackageManagerTabs\n  command={{\n    npm: \"npm add @scope/pkg\",\n    \
+            deno: \"deno add jsr:@scope/pkg\",\n  }}\n/>\n\n\
+            {/* a JSX comment with \"quotes\" */}\n";
+        let options = Options {
+            mdx: true,
+            ..Options::default()
+        };
+        let result = format(input, &options).unwrap();
+        assert_eq!(result, input, "MDX constructs should be preserved verbatim");
+        let again = format(&result, &options).unwrap();
+        assert_eq!(result, again, "MDX formatting should be idempotent");
+    }
+
+    /// Prose interleaved with MDX constructs is still formatted while the
+    /// constructs are preserved.
+    #[test]
+    fn prose_between_constructs_is_formatted() {
+        let input = "import { x } from \"y\";\n\n\
+            This paragraph has \"smart quotes\" and needs no wrapping.\n\n\
+            <Chart data={x} />\n";
+        let options = Options {
+            mdx: true,
+            ..Options::default()
+        };
+        let result = format(input, &options).unwrap();
+        assert!(result.contains("import { x } from \"y\";"));
+        assert!(result.contains("<Chart data={x} />"));
+        assert!(
+            result.contains('\u{201c}'),
+            "prose quotes should curl: {result:?}"
+        );
+        assert_eq!(result, format(&result, &options).unwrap());
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -263,6 +263,124 @@ mod mdx_esm {
     }
 }
 
+/// MDX mode: JSX elements and fragments that comrak would corrupt are preserved
+/// verbatim, while plain prose around them is still formatted.
+mod mdx_jsx {
+    use hongdown::{Options, format};
+
+    fn mdx_options() -> Options {
+        Options {
+            mdx: true,
+            ..Options::default()
+        }
+    }
+
+    /// A single-line tag with an expression attribute is corrupted without MDX
+    /// mode (its string literal is curled) and preserved with it.
+    #[test]
+    fn single_line_expression_attribute() {
+        let input = "<Chart data={{ title: \"Hello\" }} />\n";
+        let off = format(input, &Options::default()).unwrap();
+        assert!(
+            off.contains('\u{201c}'),
+            "expected corruption when off: {off:?}"
+        );
+        let on = format(input, &mdx_options()).unwrap();
+        assert_eq!(on, input);
+    }
+
+    /// A multi-line self-closing element (open tag incomplete on line 1) loses
+    /// its indentation and curls quotes without MDX mode; with it, every byte is
+    /// preserved.
+    #[test]
+    fn multiline_self_closing_element() {
+        let input =
+            "<PackageManagerTabs\n  command={{\n    npm: \"npm add @scope/pkg\",\n  }}\n/>\n";
+        let off = format(input, &Options::default()).unwrap();
+        assert_ne!(off, input, "expected corruption when off");
+        let on = format(input, &mdx_options()).unwrap();
+        assert_eq!(on, input);
+    }
+
+    /// JSX fragments are preserved verbatim.
+    #[test]
+    fn fragment_preserved() {
+        let input = "<>It's a \"fragment\"</>\n";
+        let on = format(input, &mdx_options()).unwrap();
+        assert_eq!(on, input);
+        let off = format(input, &Options::default()).unwrap();
+        assert!(
+            off.contains('\u{201c}'),
+            "expected corruption when off: {off:?}"
+        );
+    }
+
+    /// A container element with an expression attribute is preserved as a whole.
+    #[test]
+    fn braced_container_preserved() {
+        let input = "<Tabs value={selected}>It's \"nested\" content</Tabs>\n";
+        let on = format(input, &mdx_options()).unwrap();
+        assert_eq!(on, input);
+    }
+
+    /// A plain (brace-free, single-line) tag is handled by comrak already, so MDX
+    /// mode does not change it.
+    #[test]
+    fn plain_container_unchanged() {
+        let input = "<Note type=\"tip\">Some text here.</Note>\n";
+        let on = format(input, &mdx_options()).unwrap();
+        let off = format(input, &Options::default()).unwrap();
+        assert_eq!(on, off);
+    }
+
+    /// Inside a plain container, a braced child element is still protected
+    /// individually while the surrounding prose is formatted: the child's string
+    /// literal keeps straight quotes, but the prose quotes are curled.
+    #[test]
+    fn braced_child_in_plain_container() {
+        let input = "<Note>It's \"great\" and <Badge label={\"wow\"} /> indeed.</Note>\n";
+        let on = format(input, &mdx_options()).unwrap();
+        assert!(
+            on.contains("label={\"wow\"}"),
+            "child should keep straight quotes: {on:?}"
+        );
+        assert!(on.contains('\u{201c}'), "prose quotes should curl: {on:?}");
+    }
+
+    /// An inline JSX element in prose is preserved while the surrounding prose is
+    /// still punctuation-transformed.
+    #[test]
+    fn inline_jsx_in_prose() {
+        let input = "He said \"hi\" then <Badge count={n} /> appeared.\n";
+        let on = format(input, &mdx_options()).unwrap();
+        assert!(on.contains("<Badge count={n} />"));
+        assert!(
+            on.contains('\u{201c}'),
+            "prose quotes should still curl: {on:?}"
+        );
+    }
+
+    /// Formatting an MDX document with JSX is idempotent.
+    #[test]
+    fn jsx_idempotent() {
+        let input = "<Chart data={{ title: \"Hello\" }} />\n\n\
+            A paragraph with \"quotes\" and a <Badge count={n} /> inline element.\n";
+        let options = mdx_options();
+        let first = format(input, &options).unwrap();
+        let second = format(&first, &options).unwrap();
+        assert_eq!(first, second);
+    }
+
+    /// Comparison operators and stray `<` in prose are not mistaken for JSX.
+    #[test]
+    fn comparison_not_treated_as_jsx() {
+        let input = "If a < b and c > d then proceed.\n";
+        let on = format(input, &mdx_options()).unwrap();
+        let off = format(input, &Options::default()).unwrap();
+        assert_eq!(on, off);
+    }
+}
+
 mod cli_tests {
     use std::io::Write;
     use std::process::{Command, Stdio};

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -302,6 +302,18 @@ mod mdx_jsx {
         assert_eq!(on, input);
     }
 
+    /// A multi-line opening tag with no `{…}` attribute is also corrupted by
+    /// comrak (it is multi-line inline HTML it does not round-trip) and is
+    /// preserved by MDX mode.
+    #[test]
+    fn multiline_opener_without_expression() {
+        let input = "<Chart\n  data=\"value\"\n/>\n";
+        let off = format(input, &Options::default()).unwrap();
+        assert_ne!(off, input, "expected corruption when off");
+        let on = format(input, &mdx_options()).unwrap();
+        assert_eq!(on, input);
+    }
+
     /// JSX fragments are preserved verbatim.
     #[test]
     fn fragment_preserved() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -164,6 +164,105 @@ fn test_whitespace_only() {
     assert!(result.trim().is_empty() || result.is_empty());
 }
 
+/// MDX mode: ESM `import`/`export` statements are preserved verbatim instead of
+/// being mangled by punctuation transforms and Markdown escaping.
+mod mdx_esm {
+    use hongdown::{LineWidth, Options, format};
+
+    fn mdx_options() -> Options {
+        Options {
+            mdx: true,
+            ..Options::default()
+        }
+    }
+
+    /// Without MDX mode (the default), an import's string literal is corrupted:
+    /// its straight double quotes become curly quotes.  This pins MDX mode as
+    /// strictly opt-in.
+    #[test]
+    fn esm_corrupted_when_mdx_disabled() {
+        let input = "import { Chart } from \"./chart.js\";\n";
+        let result = format(input, &Options::default()).unwrap();
+        assert!(
+            result.contains('\u{201c}') || result.contains('\u{201d}'),
+            "expected curly quotes when MDX mode is off: {result:?}"
+        );
+        assert!(!result.contains("from \"./chart.js\""));
+    }
+
+    /// With MDX mode on, the import line is preserved byte-for-byte.
+    #[test]
+    fn esm_import_preserved_when_mdx_enabled() {
+        let input = "import { Chart } from \"./chart.js\";\n";
+        let result = format(input, &mdx_options()).unwrap();
+        assert_eq!(result, "import { Chart } from \"./chart.js\";\n");
+    }
+
+    /// `export const … = { … }` with single quotes is preserved verbatim.
+    #[test]
+    fn esm_export_object_preserved() {
+        let input = "export const meta = { author: 'Hong Minhee' };\n";
+        let result = format(input, &mdx_options()).unwrap();
+        assert_eq!(result, "export const meta = { author: 'Hong Minhee' };\n");
+    }
+
+    /// A multi-line import (brace list spanning lines) is preserved verbatim,
+    /// including its internal newlines and indentation.
+    #[test]
+    fn esm_multiline_import_preserved() {
+        let input = "import {\n  Chart,\n  Tabs,\n} from \"./ui.js\";\n";
+        let result = format(input, &mdx_options()).unwrap();
+        assert_eq!(result, input);
+    }
+
+    /// Surrounding prose is still formatted (wrapped at the line width) while the
+    /// import passes through untouched.
+    #[test]
+    fn esm_prose_still_wraps() {
+        let input = "import { Chart } from \"./chart.js\";\n\n\
+            This is a fairly long paragraph of prose that comfortably exceeds the \
+            eighty column width and therefore must be wrapped by the formatter.\n";
+        let options = Options {
+            line_width: Some(LineWidth::new(80).unwrap()),
+            ..mdx_options()
+        };
+        let result = format(input, &options).unwrap();
+        assert!(result.contains("import { Chart } from \"./chart.js\";"));
+        // The prose paragraph must have been wrapped onto multiple lines.
+        let prose = result.split("\n\n").nth(1).unwrap_or("");
+        assert!(
+            prose.lines().count() > 1,
+            "expected the prose to wrap: {result:?}"
+        );
+        assert!(prose.lines().all(|line| line.chars().count() <= 80));
+    }
+
+    /// Formatting an MDX document with ESM statements twice yields identical
+    /// output.
+    #[test]
+    fn esm_idempotent() {
+        let input = "import { Chart } from \"./chart.js\";\n\n\
+            export const meta = { author: 'Hong Minhee' };\n\n\
+            Some prose with \"quotes\" and -- dashes.\n";
+        let options = mdx_options();
+        let first = format(input, &options).unwrap();
+        let second = format(&first, &options).unwrap();
+        assert_eq!(first, second, "MDX formatting should be idempotent");
+        assert!(first.contains("import { Chart } from \"./chart.js\";"));
+        assert!(first.contains("export const meta = { author: 'Hong Minhee' };"));
+    }
+
+    /// MDX mode does not change a plain Markdown document that has no MDX
+    /// constructs: output equals the default-options output.
+    #[test]
+    fn no_change_for_plain_markdown() {
+        let input = "# Title\n\nA paragraph with \"quotes\" and a [link](https://example.com/).\n";
+        let with_mdx = format(input, &mdx_options()).unwrap();
+        let without_mdx = format(input, &Options::default()).unwrap();
+        assert_eq!(with_mdx, without_mdx);
+    }
+}
+
 mod cli_tests {
     use std::io::Write;
     use std::process::{Command, Stdio};

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -531,7 +531,22 @@ mod mdx_expressions {
 /// MDX mode end to end: the full reproduction from the issue round-trips
 /// byte-for-byte and is idempotent.
 mod mdx_document {
-    use hongdown::{Options, format};
+    use hongdown::{Options, format, format_with_warnings};
+
+    /// A warning after a multi-line construct (collapsed to a one-line
+    /// placeholder while formatting) is still reported at its original line.
+    #[test]
+    fn warning_line_maps_back_across_multiline_construct() {
+        let input = "import {\n  a,\n  b,\n} from \"x\";\n\nText with [an undefined ref] here.\n";
+        let options = Options {
+            mdx: true,
+            ..Options::default()
+        };
+        let result = format_with_warnings(input, &options).unwrap();
+        assert_eq!(result.warnings.len(), 1, "{:?}", result.warnings);
+        // The undefined reference is on line 6 of the original source.
+        assert_eq!(result.warnings[0].line, 6);
+    }
 
     #[test]
     fn issue_reproduction_preserved_and_idempotent() {


### PR DESCRIPTION
Hongdown mangled MDX files. comrak has no notion of MDX's JavaScript and JSX, so it parsed ESM imports, JSX elements, and `{…}` expressions as ordinary prose and then ran them through the punctuation transforms and Markdown escaping: straight quotes turned curly, `*` and backticks got backslash-escaped, and indentation collapsed. This adds an opt-in MDX mode that leaves the embedded code alone while still formatting the Markdown around it.

The approach is protective pre/post-processing, in a new *src/mdx.rs*. Before the source reaches comrak, the constructs comrak would corrupt are replaced with unique HTML-comment placeholders; comrak emits those verbatim, so they survive serialization untouched while the surrounding prose is wrapped and punctuation-transformed as usual, and the placeholders are swapped back afterward. Detection runs off comrak's own parse: the pre-pass scans only the source spans of paragraph nodes, so fenced code, inline code, math, front matter, headings, and existing HTML blocks are left alone.

Three kinds of construct are protected when they appear in paragraph text and comrak would otherwise corrupt them:

 -  ESM `import`/`export` statements, including multi-line ones.
 -  JSX elements that comrak would parse as prose rather than inline HTML: fragments `<>…</>`, multi-line openers, and tags with `{…}` expression attributes that break CommonMark's tag grammar.
 -  `{…}` expressions, including `{/* … */}` comments.

A few things are deliberately left to comrak. A valid single-line inline-HTML tag keeps its tag while the element's Markdown children are still formatted. Braces inside inline code, math, or link/image syntax stay put, and an explicit `{#id}` heading anchor remains an anchor. Where telling a regex literal from division would need a real JavaScript parser (a `/` right after `}`), or where an ESM object's body contains a blank line, the construct is left unprotected rather than risk mis-protecting it.

Activation mirrors the existing `math` option and is off by default. Files with the *.mdx* extension turn it on automatically, and *.mdx* is now found during recursive directory discovery. For other input there is a `--mdx` flag, an `mdx` option in *.hongdown.toml*, and an `mdx` field in the WASM/JavaScript API.

This also fixes two pre-existing serializer bugs around HTML blocks: a document whose only content was HTML blocks gained two leading blank lines, and two trailing HTML blocks separated by a blank line were emitted on adjacent lines. Both now round-trip correctly, which also keeps MDX placeholders laid out as written.

The behavior is documented in *README.md* and *STYLE.md*, each with a new MDX section, with the release note in *CHANGES.md*.

One known limitation: a warning's line number can be reported a little early when the warning source follows a multi-line construct embedded inline in the same paragraph. Only the warning position is affected, not the formatting or restoration; block-level multi-line constructs, the common case, map back exactly.

AI usage: the implementation and tests were written with Claude Code (Opus 4.8) under test-driven development, and reviewed with Codex (GPT-5.5) in a review loop before every commit and once more across the whole branch. I read and verified the result.

Fixes <https://github.com/dahlia/hongdown/issues/22>.