### PR TITLE
Keep link targets when reference labels collide

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,30 @@ Version 0.5.2
 
 To be released.
 
+ -  Fixed a bug where formatting could silently change a link's destination.
+    Reference labels are generated from the link text, so two links with the
+    same text but different destinations were given the same label, and the
+    later definition overwrote the earlier one.  A label is now shared only
+    when the complete target matches, meaning both the URL and the title;
+    otherwise the colliding link gets a numbered label and full reference
+    syntax, as in `[guide][guide 2]`.  [[#26], [#29]]
+
+ -  Fixed a bug where a reference definition needed by a later section was
+    dropped entirely when an earlier section had already defined the same
+    label with a different destination, leaving the later link pointing at
+    the earlier section's URL.  [[#26], [#29]]
+
+ -  Fixed a bug where reference labels differing only in letter case, such as
+    `[Guide]` and `[guide]`, were emitted as two separate definitions.  Since
+    CommonMark matches reference labels case-insensitively, parsers ignored
+    the second definition and both links resolved to the first URL.  Labels
+    are now compared with runs of whitespace collapsed and Unicode case
+    folding applied, the same way the underlying parser resolves them.
+    [[#26], [#29]]
+
+[#26]: https://github.com/dahlia/hongdown/issues/26
+[#29]: https://github.com/dahlia/hongdown/pull/29
+
 
 Version 0.5.1
 -------------

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -510,6 +510,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 name = "hongdown"
 version = "0.5.2"
 dependencies = [
+ "caseless",
  "clap",
  "comrak",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,7 @@ js-sys = { version = "0.3", optional = true }
 getrandom = { version = "0.3", features = ["wasm_js"], optional = true }
 ignore = "0.4.25"
 dirs = "6.0.0"
+caseless = "0.2.2"
 
 [dev-dependencies]
 tempfile = "3.24.0"

--- a/STYLE.md
+++ b/STYLE.md
@@ -411,6 +411,31 @@ See [GitHub][][^1] for details.
 full reference link with label `^1`, which would break the intended link and
 footnote.
 
+### Distinct labels for distinct targets
+
+A reference label may be shared only by links that point at the very same
+target, meaning the same URL *and* the same title.  When the label a link
+would otherwise take is already used for a different target, the link gets a
+numbered label and full reference syntax:
+
+~~~~ markdown
+ -  Read [guide].
+ -  Read [guide][guide 2].
+
+[guide]: https://example.com/first
+[guide 2]: https://example.com/second
+~~~~
+
+Labels are compared the way CommonMark resolves them: with runs of whitespace
+collapsed and Unicode case folding applied.  So `[Guide]` and `[guide]` are
+the same label, as are `[Straße]` and `[STRASSE]`, and one of them is
+renumbered unless both point at the same target.
+
+*Rationale*: A reference definition is document-wide, and a duplicate
+definition is ignored by the parser rather than merged.  Sharing a label
+between different targets would therefore silently change where one of the
+links points, and formatting must never do that.
+
 
 Block quotes and alerts
 -----------------------

--- a/src/serializer/inline.rs
+++ b/src/serializer/inline.rs
@@ -236,15 +236,11 @@ impl<'a> Serializer<'a> {
                         for child in node.children() {
                             self.collect_inline_node(child, content);
                         }
+                        let actual_label =
+                            self.register_reference(actual_label, &link.url, &link.title);
                         content.push_str("][");
-                        content.push_str(actual_label);
+                        content.push_str(&actual_label);
                         content.push(']');
-
-                        self.add_reference(
-                            actual_label.to_string(),
-                            link.url.clone(),
-                            link.title.clone(),
-                        );
                     } else {
                         // Non-badge reference links: use helper
                         self.format_reference_link(content, &text, &label, &link.url, &link.title);

--- a/src/serializer/link.rs
+++ b/src/serializer/link.rs
@@ -14,30 +14,27 @@ impl<'a> Serializer<'a> {
         url: &str,
         title: &str,
     ) {
-        if label.starts_with('\x01') {
-            // Collapsed reference: [text][]
-            let actual_label = label.strip_prefix('\x01').unwrap();
-            output.push('[');
-            output.push_str(text);
-            output.push_str("][]");
+        let collapsed = label.starts_with('\x01');
+        let label = label.strip_prefix('\x01').unwrap_or(label);
+        // The label may already be taken by a different target, in which case a
+        // distinct one is allocated and the full reference form is required.
+        let label = self.register_reference(label, url, title);
 
-            self.add_reference(actual_label.to_string(), url.to_string(), title.to_string());
-        } else if text == label {
-            // Shortcut reference: [text]
-            output.push('[');
-            output.push_str(text);
-            output.push(']');
-
-            self.add_reference(label.to_string(), url.to_string(), title.to_string());
+        output.push('[');
+        output.push_str(text);
+        if label == text {
+            if collapsed {
+                // Collapsed reference: [text][]
+                output.push_str("][]");
+            } else {
+                // Shortcut reference: [text]
+                output.push(']');
+            }
         } else {
             // Full reference: [text][label]
-            output.push('[');
-            output.push_str(text);
             output.push_str("][");
-            output.push_str(label);
+            output.push_str(&label);
             output.push(']');
-
-            self.add_reference(label.to_string(), url.to_string(), title.to_string());
         }
     }
 
@@ -77,14 +74,22 @@ impl<'a> Serializer<'a> {
     ) {
         // Normalize: replace SoftBreak markers with spaces for shortcut refs
         let normalized_text = text.replace('\x00', " ");
+        // The link text is only usable as the label when it is not already
+        // taken by a different target; otherwise fall back to a full reference.
+        let label = self.register_reference(&normalized_text, url, title);
+
         output.push('[');
         output.push_str(&normalized_text);
-        output.push(']');
-        if use_collapsed {
-            output.push_str("[]");
+        if label == normalized_text {
+            output.push(']');
+            if use_collapsed {
+                output.push_str("[]");
+            }
+        } else {
+            output.push_str("][");
+            output.push_str(&label);
+            output.push(']');
         }
-
-        self.add_reference(normalized_text, url.to_string(), title.to_string());
     }
 
     /// Check if the next sibling of a node starts with `[`.
@@ -110,30 +115,25 @@ impl<'a> Serializer<'a> {
         url: &str,
         title: &str,
     ) {
-        if label.starts_with('\x01') {
-            // Collapsed reference: ![alt][]
-            let actual_label = label.strip_prefix('\x01').unwrap();
-            output.push_str("![");
-            output.push_str(text);
-            output.push_str("][]");
+        let collapsed = label.starts_with('\x01');
+        let label = label.strip_prefix('\x01').unwrap_or(label);
+        let label = self.register_reference(label, url, title);
 
-            self.add_reference(actual_label.to_string(), url.to_string(), title.to_string());
-        } else if text == label {
-            // Shortcut reference: ![alt]
-            output.push_str("![");
-            output.push_str(text);
-            output.push(']');
-
-            self.add_reference(label.to_string(), url.to_string(), title.to_string());
+        output.push_str("![");
+        output.push_str(text);
+        if label == text {
+            if collapsed {
+                // Collapsed reference: ![alt][]
+                output.push_str("][]");
+            } else {
+                // Shortcut reference: ![alt]
+                output.push(']');
+            }
         } else {
             // Full reference: ![alt][label]
-            output.push_str("![");
-            output.push_str(text);
             output.push_str("][");
-            output.push_str(label);
+            output.push_str(&label);
             output.push(']');
-
-            self.add_reference(label.to_string(), url.to_string(), title.to_string());
         }
     }
 
@@ -172,9 +172,9 @@ impl<'a> Serializer<'a> {
                 }
                 self.output.push_str("][");
                 let actual_label = label.strip_prefix('\x01').unwrap_or(&label);
-                self.output.push_str(actual_label);
+                let actual_label = self.register_reference(actual_label, url, title);
+                self.output.push_str(&actual_label);
                 self.output.push(']');
-                self.add_reference(actual_label.to_string(), url.to_string(), title.to_string());
             } else {
                 // Use helper for non-badge reference links
                 let mut output = String::new();
@@ -217,9 +217,6 @@ impl<'a> Serializer<'a> {
     }
 
     pub(super) fn serialize_image<'b>(&mut self, node: &'b AstNode<'b>, url: &str, title: &str) {
-        // Collect the alt text
-        let alt_text = self.collect_text(node);
-
         // Check if original was reference style
         if let Some((text, label)) = self.get_reference_style_info(node) {
             // Use a temporary buffer to avoid double borrow
@@ -229,7 +226,11 @@ impl<'a> Serializer<'a> {
             return;
         }
 
-        // Inline style: ![alt](url)
+        // Inline style: ![alt](url).  The alt text is collected only here:
+        // collecting it up front would register reference definitions for any
+        // links inside it even when the output is discarded, reserving labels
+        // that never appear in the document.
+        let alt_text = self.collect_text(node);
         Self::format_inline_image(&mut self.output, &alt_text, url, title);
     }
 }

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -201,9 +201,9 @@ impl<'a> Serializer<'a> {
         // Filter out references that have already been emitted
         let refs: Vec<ReferenceLink> = self
             .pending_references
-            .values()
-            .filter(|r| !self.emitted_references.contains(&r.label))
-            .cloned()
+            .iter()
+            .filter(|(key, _)| !self.emitted_references.contains_key(*key))
+            .map(|(_, r)| r.clone())
             .collect();
         self.pending_references.clear();
 
@@ -223,7 +223,7 @@ impl<'a> Serializer<'a> {
             // Less than 2 numeric refs: output all in insertion order
             for reference in &refs {
                 Self::write_reference(&mut self.output, reference);
-                self.emitted_references.insert(reference.label.clone());
+                self.mark_reference_emitted(reference);
             }
         } else {
             // 2+ numeric refs: separate, sort numeric ones, output regular first
@@ -244,15 +244,24 @@ impl<'a> Serializer<'a> {
             // Output regular references first (in insertion order)
             for reference in regular_refs {
                 Self::write_reference(&mut self.output, reference);
-                self.emitted_references.insert(reference.label.clone());
+                self.mark_reference_emitted(reference);
             }
 
             // Output numeric references (sorted by number)
             for (_, reference) in numeric_refs {
                 Self::write_reference(&mut self.output, reference);
-                self.emitted_references.insert(reference.label.clone());
+                self.mark_reference_emitted(reference);
             }
         }
+    }
+
+    /// Record that a reference definition has been written out, so that later
+    /// sections neither repeat it nor reuse its label for a different target.
+    fn mark_reference_emitted(&mut self, reference: &ReferenceLink) {
+        self.emitted_references.insert(
+            state::normalize_reference_key(&reference.label),
+            reference.clone(),
+        );
     }
 
     /// Extract numeric value from a reference label like "123" or "#123"
@@ -377,8 +386,8 @@ impl<'a> Serializer<'a> {
         let mut to_emit: Vec<ReferenceLink> = Vec::new();
         let mut to_keep: Vec<(String, (ReferenceLink, usize))> = Vec::new();
 
-        for (label, (reference, footnote_ref_line)) in self.footnotes.pending_references.drain(..) {
-            if self.emitted_references.contains(&label) {
+        for (key, (reference, footnote_ref_line)) in self.footnotes.pending_references.drain(..) {
+            if self.emitted_references.contains_key(&key) {
                 continue;
             }
             let should_emit = match before_line {
@@ -388,7 +397,7 @@ impl<'a> Serializer<'a> {
             if should_emit {
                 to_emit.push(reference);
             } else {
-                to_keep.push((label, (reference, footnote_ref_line)));
+                to_keep.push((key, (reference, footnote_ref_line)));
             }
         }
 
@@ -406,7 +415,7 @@ impl<'a> Serializer<'a> {
         // Output references in insertion order
         for reference in &to_emit {
             Self::write_reference(&mut self.output, reference);
-            self.emitted_references.insert(reference.label.clone());
+            self.mark_reference_emitted(reference);
         }
     }
 

--- a/src/serializer/state.rs
+++ b/src/serializer/state.rs
@@ -98,6 +98,57 @@ pub struct ReferenceLink {
     pub title: String,
 }
 
+/// The longest reference label a CommonMark parser accepts, in bytes.
+///
+/// Matches comrak's own `MAX_LINK_LABEL_LENGTH`; a longer label makes the
+/// parser reject the whole link, so a generated label must stay within it.
+const MAX_REFERENCE_LABEL_BYTES: usize = 1000;
+
+/// Normalize a reference label into the key used to look it up.
+///
+/// CommonMark matches reference labels after collapsing internal whitespace
+/// and applying Unicode default case folding, so labels that differ only in
+/// spacing or case refer to the same definition and must share a single key.
+/// This mirrors comrak's `normalize_label(_, Case::Fold)`, down to using the
+/// same case folding implementation: plain lowercasing would miss pairs such
+/// as `Straße` and `STRASSE`.  The internal SoftBreak marker is treated as
+/// the space it will be emitted as.
+pub fn normalize_reference_key(label: &str) -> String {
+    caseless::default_case_fold_str(&super::escape::normalize_whitespace(
+        &label.replace('\x00', " "),
+    ))
+}
+
+/// The longest suffix [`numbered_reference_label`] appends, in bytes: a space
+/// plus a `u32` in decimal.
+const MAX_REFERENCE_LABEL_SUFFIX_BYTES: usize = 11;
+
+/// Shorten a label, at a character boundary, so that any numbered suffix still
+/// fits within [`MAX_REFERENCE_LABEL_BYTES`].  Labels that are already short
+/// enough are returned unchanged.
+///
+/// An over-long label is rejected by the parser on the next pass, turning the
+/// link into literal text and losing its destination.  The amount removed does
+/// not depend on the number, so every numbered variant of a given label shares
+/// one namespace; a number-dependent cut would let labels that shorten to the
+/// same prefix allocate against each other unnoticed.
+fn truncate_reference_label_base(label: &str) -> &str {
+    let budget = MAX_REFERENCE_LABEL_BYTES - MAX_REFERENCE_LABEL_SUFFIX_BYTES;
+    if label.len() <= budget {
+        return label;
+    }
+    let mut end = budget;
+    while end > 0 && !label.is_char_boundary(end) {
+        end -= 1;
+    }
+    &label[..end]
+}
+
+/// Build the `n`th numbered variant of `label`, such as `guide 2`.
+fn numbered_reference_label(label: &str, n: u32) -> String {
+    format!("{} {n}", truncate_reference_label_base(label))
+}
+
 /// A footnote definition: name -> content
 #[derive(Debug, Clone)]
 pub struct FootnoteDefinition {
@@ -134,6 +185,7 @@ pub struct FootnoteSet {
     /// Used to associate references with their parent footnote's timing.
     pub current_reference_line: usize,
     /// Reference links collected from within footnote definitions.
+    /// Key: normalized label (see `normalize_reference_key`).
     /// Value is (ReferenceLink, footnote_reference_line) to track when to flush.
     pub pending_references: IndexMap<String, (ReferenceLink, usize)>,
 }
@@ -179,10 +231,11 @@ impl FootnoteSet {
         self.current_reference_line = 0;
     }
 
-    /// Add a reference link found within footnote content.
-    pub fn add_reference(&mut self, label: String, reference: ReferenceLink) {
+    /// Add a reference link found within footnote content, under its
+    /// normalized lookup key.
+    pub fn add_reference(&mut self, key: String, reference: ReferenceLink) {
         self.pending_references
-            .insert(label, (reference, self.current_reference_line));
+            .insert(key, (reference, self.current_reference_line));
     }
 }
 
@@ -248,10 +301,19 @@ pub struct Serializer<'a> {
     /// Accumulated blockquote prefix for nested blockquotes (e.g., "> " or "> > ")
     pub blockquote_prefix: String,
     /// Reference links collected for the current section
-    /// Key: label, Value: ReferenceLink (insertion order preserved)
+    /// Key: normalized label (see `normalize_reference_key`),
+    /// Value: ReferenceLink (insertion order preserved)
     pub pending_references: IndexMap<String, ReferenceLink>,
-    /// Reference labels that have already been emitted (to avoid duplicates)
-    pub emitted_references: std::collections::HashSet<String>,
+    /// Reference links that have already been emitted (to avoid duplicates)
+    /// Key: normalized label, Value: the target it was emitted with
+    pub emitted_references: std::collections::HashMap<String, ReferenceLink>,
+    /// The next numbered variant to try for a label whose earlier variants are
+    /// all taken.  Key: normalized label of the base.
+    pub reference_label_cursors: std::collections::HashMap<String, u32>,
+    /// Numbered variants already handed out, so that a target appearing again
+    /// reuses its variant instead of being given another one.
+    /// Key: (normalized label of the base, url, title)
+    pub numbered_reference_labels: std::collections::HashMap<(String, String, String), String>,
     /// Footnote definitions and their reference tracking
     pub footnotes: FootnoteSet,
     /// Current list nesting depth (0 = not in list, 1 = top-level, 2+ = nested)
@@ -306,7 +368,9 @@ impl<'a> Serializer<'a> {
             in_block_quote: false,
             blockquote_prefix: String::new(),
             pending_references: IndexMap::new(),
-            emitted_references: std::collections::HashSet::new(),
+            emitted_references: std::collections::HashMap::new(),
+            reference_label_cursors: std::collections::HashMap::new(),
+            numbered_reference_labels: std::collections::HashMap::new(),
             footnotes: FootnoteSet::new(),
             list_depth: 0,
             skip_mode: FormatSkipMode::None,
@@ -344,7 +408,9 @@ impl<'a> Serializer<'a> {
             in_block_quote: false,
             blockquote_prefix: String::new(),
             pending_references: IndexMap::new(),
-            emitted_references: std::collections::HashSet::new(),
+            emitted_references: std::collections::HashMap::new(),
+            reference_label_cursors: std::collections::HashMap::new(),
+            numbered_reference_labels: std::collections::HashMap::new(),
             footnotes: FootnoteSet::new(),
             list_depth: 0,
             skip_mode: FormatSkipMode::None,
@@ -447,19 +513,106 @@ impl<'a> Serializer<'a> {
         self.skip_mode != FormatSkipMode::None
     }
 
-    /// Add a reference link to the pending references.
-    /// If collecting_footnote_content is true, adds to pending_footnote_references instead,
-    /// along with the current footnote's reference line for proper flush timing.
-    pub fn add_reference(&mut self, label: String, url: String, title: String) {
+    /// Look up a reference that has already been registered under `key`,
+    /// whether it is still pending or has already been emitted.
+    fn find_reference(&self, key: &str) -> Option<&ReferenceLink> {
+        self.emitted_references
+            .get(key)
+            .or_else(|| self.pending_references.get(key))
+            .or_else(|| self.footnotes.pending_references.get(key).map(|(r, _)| r))
+    }
+
+    /// Register a reference link and return the label that must be used to
+    /// refer to it.
+    ///
+    /// A label may only be shared by links whose complete target (both URL and
+    /// title) is identical; sharing it otherwise would silently change one of
+    /// the links' destinations.  When the desired label is already taken by a
+    /// different target, a distinct label is derived from it by appending a
+    /// number, and the caller must fall back to full reference syntax.
+    ///
+    /// If collecting_footnote_content is true, the reference is added to
+    /// pending_footnote_references instead, along with the current footnote's
+    /// reference line for proper flush timing.
+    pub fn register_reference(&mut self, label: &str, url: &str, title: &str) -> String {
+        let key = normalize_reference_key(label);
+        match self.find_reference(&key) {
+            // Free label: take it.
+            None => {
+                self.insert_reference(key, label.to_string(), url, title);
+                label.to_string()
+            }
+            // Already registered with the same target: share it.  The existing
+            // entry is left untouched so that its spelling (and, once emitted,
+            // its definition) is not duplicated or altered.
+            Some(existing) if existing.url == url && existing.title == title => label.to_string(),
+            // Taken by a different target: derive a distinct label.
+            Some(_) => {
+                // The variants live in the namespace of the shortened base, so
+                // that is what both the cursor and the reuse map are keyed by:
+                // labels long enough to be shortened to the same prefix share
+                // one namespace and must not allocate against each other.
+                let cursor_key = normalize_reference_key(truncate_reference_label_base(label));
+                // Reuse the variant this target was already given, if any.
+                // Looking it up directly keeps a document full of same-text
+                // links from rescanning every variant it has handed out.
+                let target = (cursor_key.clone(), url.to_string(), title.to_string());
+                if let Some(label) = self.numbered_reference_labels.get(&target) {
+                    return label.clone();
+                }
+                // Every variant below the cursor is already taken, and taken
+                // labels are never released, so the search can resume there.
+                let start = self
+                    .reference_label_cursors
+                    .get(&cursor_key)
+                    .copied()
+                    .unwrap_or(2);
+                for n in start.. {
+                    let candidate = numbered_reference_label(label, n);
+                    let candidate_key = normalize_reference_key(&candidate);
+                    // Copy the occupant out of the borrow so the maps below can
+                    // be updated.
+                    let occupant = self
+                        .find_reference(&candidate_key)
+                        .map(|existing| (existing.url.clone(), existing.title.clone()));
+                    match occupant {
+                        // Occupied by something else.  Remember what, because
+                        // the cursor will not visit this variant again and a
+                        // later link to that same target must find it here
+                        // rather than allocating a duplicate for it.
+                        Some((occupied_url, occupied_title))
+                            if occupied_url != url || occupied_title != title =>
+                        {
+                            self.numbered_reference_labels
+                                .entry((cursor_key.clone(), occupied_url, occupied_title))
+                                .or_insert(candidate);
+                            continue;
+                        }
+                        // Already holds this very target: share it.
+                        Some(_) => {}
+                        None => self.insert_reference(candidate_key, candidate.clone(), url, title),
+                    }
+                    self.reference_label_cursors.insert(cursor_key, n + 1);
+                    self.numbered_reference_labels
+                        .insert(target, candidate.clone());
+                    return candidate;
+                }
+                unreachable!("the numbered label space is unbounded")
+            }
+        }
+    }
+
+    /// Store a new reference definition under an unused key.
+    fn insert_reference(&mut self, key: String, label: String, url: &str, title: &str) {
         let reference = ReferenceLink {
-            label: label.clone(),
-            url,
-            title,
+            label,
+            url: url.to_string(),
+            title: title.to_string(),
         };
         if self.footnotes.collecting_content {
-            self.footnotes.add_reference(label, reference);
+            self.footnotes.add_reference(key, reference);
         } else {
-            self.pending_references.insert(label, reference);
+            self.pending_references.insert(key, reference);
         }
     }
 

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -5359,3 +5359,378 @@ fn test_code_block_in_list_item_in_alert() {
     let twice = parse_and_serialize_with_source(&once);
     assert_eq!(once, twice, "alert list code block is not idempotent");
 }
+
+#[test]
+fn test_duplicate_link_text_different_urls_get_distinct_labels() {
+    // Two links with the same text but different destinations must not share
+    // a reference label; otherwise the first link silently changes target.
+    let input = " -  Read [guide](https://example.com/first).\n \
+                 -  Read [guide](https://example.com/second).\n";
+    let result = parse_and_serialize(input);
+    assert!(
+        result.contains("[guide]: https://example.com/first"),
+        "first destination should be preserved, got:\n{}",
+        result
+    );
+    assert!(
+        result.contains("[guide 2]: https://example.com/second"),
+        "second destination should get a distinct label, got:\n{}",
+        result
+    );
+    assert!(
+        result.contains("[guide][guide 2]"),
+        "colliding link should use full reference syntax, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_duplicate_link_text_same_url_reuses_label() {
+    // Identical targets should still share a single definition.
+    let input = " -  Read [guide](https://example.com/).\n \
+                 -  Read [guide](https://example.com/).\n";
+    let result = parse_and_serialize(input);
+    let count = result.matches("[guide]: https://example.com/").count();
+    assert_eq!(
+        count, 1,
+        "identical targets should share one definition, got:\n{}",
+        result
+    );
+    assert!(
+        !result.contains("guide 2"),
+        "identical targets should not be renamed, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_duplicate_link_text_same_url_different_title_distinct_labels() {
+    // The title is part of the link target, so differing titles collide too.
+    let input = " -  Read [guide](https://example.com/ \"First\").\n \
+                 -  Read [guide](https://example.com/ \"Second\").\n";
+    let result = parse_and_serialize(input);
+    assert!(
+        result.contains("[guide]: https://example.com/ \"First\""),
+        "first title should be preserved, got:\n{}",
+        result
+    );
+    assert!(
+        result.contains("[guide 2]: https://example.com/ \"Second\""),
+        "second title should get a distinct label, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_duplicate_link_labels_idempotent() {
+    let input = " -  Read [guide](https://example.com/first).\n \
+                 -  Read [guide](https://example.com/second).\n \
+                 -  Read [guide](https://example.com/third).\n";
+    let result = parse_and_serialize_with_source(input);
+    let result2 = parse_and_serialize_with_source(&result);
+    assert_eq!(
+        result, result2,
+        "distinct reference labels should be idempotent.\nFirst pass:\n{}\nSecond pass:\n{}",
+        result, result2
+    );
+    assert!(
+        result.contains("[guide 3]: https://example.com/third"),
+        "third destination should be preserved, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_link_label_collision_across_sections() {
+    // Reference definitions are document-wide, so a label emitted in an
+    // earlier section must not be redefined with a different target later.
+    let input = "Intro\n\n\
+                 Section A\n---------\n\n\
+                 Read [guide](https://example.com/first).\n\n\
+                 Section B\n---------\n\n\
+                 Read [guide](https://example.com/second).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("[guide]: https://example.com/first"),
+        "first section's destination should be preserved, got:\n{}",
+        result
+    );
+    assert!(
+        result.contains("[guide 2]: https://example.com/second"),
+        "second section's destination should not be dropped, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_link_label_collision_case_insensitive() {
+    // CommonMark matches reference labels case-insensitively, so labels
+    // differing only in case would collide in the output.
+    let input = "Read [Guide](https://example.com/first) and \
+                 [guide](https://example.com/second).\n";
+    let result = parse_and_serialize(input);
+    assert!(
+        result.contains("[Guide]: https://example.com/first"),
+        "first destination should be preserved, got:\n{}",
+        result
+    );
+    assert!(
+        result.contains("[guide 2]: https://example.com/second"),
+        "case-insensitive collision should get a distinct label, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_case_insensitive_label_same_url_reuses_definition() {
+    let input = "Read [Guide](https://example.com/) and \
+                 [guide](https://example.com/).\n";
+    let result = parse_and_serialize(input);
+    let count = result.matches("]: https://example.com/").count();
+    assert_eq!(
+        count, 1,
+        "labels differing only in case with the same target should share one \
+         definition, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_image_and_link_label_collision() {
+    // A generated link label must not clobber an image's reference definition.
+    let input = "See ![logo] and [logo](https://example.com/page).\n\n\
+                 [logo]: https://example.com/logo.png\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("[logo]: https://example.com/logo.png"),
+        "image destination should be preserved, got:\n{}",
+        result
+    );
+    assert!(
+        result.contains("[logo 2]: https://example.com/page"),
+        "link destination should get a distinct label, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_link_label_collision_inside_footnote() {
+    let input = "Text[^1] and more[^2].\n\n\
+                 [^1]: See [guide](https://example.com/first).\n\n\
+                 [^2]: See [guide](https://example.com/second).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("[guide]: https://example.com/first"),
+        "first footnote's destination should be preserved, got:\n{}",
+        result
+    );
+    assert!(
+        result.contains("[guide 2]: https://example.com/second"),
+        "second footnote's destination should be preserved, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_link_label_collision_in_heading() {
+    let input = "[guide](https://example.com/first) heading\n\
+                 -----------------------------------------\n\n\
+                 Read [guide](https://example.com/second).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("[guide]: https://example.com/first"),
+        "heading link's destination should be preserved, got:\n{}",
+        result
+    );
+    assert!(
+        result.contains("[guide 2]: https://example.com/second"),
+        "body link's destination should be preserved, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_numeric_link_label_collision() {
+    // A numbered label derived from a numeric one is no longer numeric, so it
+    // joins the regular references rather than the sorted numeric ones.
+    let input = "See [1](https://example.com/a), [1](https://example.com/b) \
+                 and [2](https://example.com/c).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("[1]: https://example.com/a"),
+        "first destination should be preserved, got:\n{}",
+        result
+    );
+    assert!(
+        result.contains("[1 2]: https://example.com/b"),
+        "colliding numeric label should get a distinct label, got:\n{}",
+        result
+    );
+    assert!(
+        result.contains("[2]: https://example.com/c"),
+        "unrelated numeric label should be untouched, got:\n{}",
+        result
+    );
+    let result2 = parse_and_serialize_with_source(&result);
+    assert_eq!(
+        result, result2,
+        "numeric label collision should be idempotent.\nFirst pass:\n{}\nSecond pass:\n{}",
+        result, result2
+    );
+}
+
+#[test]
+fn test_link_label_collision_with_explicit_reference_label() {
+    // A hand-written label and a generated one that clash must each keep
+    // their own destination, whichever comes first in the document.
+    let input = "See [the guide][guide] and later \
+                 [guide](https://example.com/other).\n\n\
+                 [guide]: https://example.com/authored\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("[guide]: https://example.com/authored"),
+        "the hand-written label should keep its destination, got:\n{}",
+        result
+    );
+    assert!(
+        result.contains("[guide 2]: https://example.com/other"),
+        "the generated label should get a distinct label, got:\n{}",
+        result
+    );
+    let result2 = parse_and_serialize_with_source(&result);
+    assert_eq!(result, result2, "should be idempotent, got:\n{}", result2);
+}
+
+#[test]
+fn test_link_label_collision_unicode_case_folding() {
+    // CommonMark folds labels with Unicode default case folding, under which
+    // "Straße" and "STRASSE" are the same label; plain lowercasing is not
+    // enough to notice the collision.
+    let input = "See [Straße](https://example.com/a) and \
+                 [STRASSE](https://example.com/b).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("[Straße]: https://example.com/a"),
+        "first destination should be preserved, got:\n{}",
+        result
+    );
+    assert!(
+        result.contains("[STRASSE 2]: https://example.com/b"),
+        "case-folded collision should get a distinct label, got:\n{}",
+        result
+    );
+    let result2 = parse_and_serialize_with_source(&result);
+    assert_eq!(result, result2, "should be idempotent, got:\n{}", result2);
+}
+
+#[test]
+fn test_link_label_collision_near_max_label_length() {
+    // A numbered label must stay within the parser's label length limit;
+    // an over-long one is rejected on the next pass, which would turn the
+    // link into literal text and lose its destination.
+    let text = "x".repeat(999);
+    let input =
+        format!("See [{text}](https://example.com/a) and [{text}](https://example.com/b).\n");
+    let result = parse_and_serialize_with_source(&input);
+    assert!(
+        result.contains("https://example.com/b"),
+        "second destination should be preserved, got:\n{}",
+        result
+    );
+    for line in result.lines() {
+        if let Some(label_len) = line.strip_prefix('[').and_then(|l| l.find("]: ")) {
+            assert!(
+                label_len <= 1000,
+                "reference label should stay within the parser's limit, got {} bytes",
+                label_len
+            );
+        }
+    }
+    let result2 = parse_and_serialize_with_source(&result);
+    assert_eq!(
+        result, result2,
+        "a label near the length limit should be idempotent"
+    );
+}
+
+#[test]
+fn test_repeated_target_reuses_its_numbered_label() {
+    // A target that already has a numbered label must reuse it rather than
+    // being handed a fresh one when it appears again.
+    let input = " -  [t](https://example.com/a)\n \
+                 -  [t](https://example.com/b)\n \
+                 -  [t](https://example.com/c)\n \
+                 -  [t](https://example.com/b)\n";
+    let result = parse_and_serialize_with_source(input);
+    let count = result.matches("]: https://example.com/b").count();
+    assert_eq!(
+        count, 1,
+        "the repeated target should keep a single definition, got:\n{}",
+        result
+    );
+    assert_eq!(
+        result.matches("[t][t 2]").count(),
+        2,
+        "both links to the repeated target should use the same label, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_near_limit_labels_sharing_a_prefix_stay_distinct() {
+    // Labels long enough to be shortened before numbering collapse to the
+    // same prefix, so their numbered variants live in one namespace and must
+    // still be allocated distinctly.
+    let prefix = "x".repeat(997);
+    let mut input = String::new();
+    for i in 0..8 {
+        let text = format!("{prefix}{i:03}");
+        input.push_str(&format!(
+            "L [{text}](https://example.com/a{i}) and [{text}](https://example.com/b{i}).\n\n"
+        ));
+    }
+    let result = parse_and_serialize_with_source(&input);
+    for i in 0..8 {
+        assert!(
+            result.contains(&format!("https://example.com/a{i}\n")),
+            "destination a{} should be preserved, got:\n{}",
+            i,
+            result
+        );
+        assert!(
+            result.contains(&format!("https://example.com/b{i}\n")),
+            "destination b{} should be preserved, got:\n{}",
+            i,
+            result
+        );
+    }
+    let result2 = parse_and_serialize_with_source(&result);
+    assert_eq!(
+        result, result2,
+        "shortened labels sharing a prefix should be idempotent"
+    );
+}
+
+#[test]
+fn test_numbered_variant_occupied_by_another_target_is_reused() {
+    // A numbered variant that is already occupied must still be found by a
+    // later link to the target it holds, rather than that target being given
+    // a second, redundant definition.
+    let input = "See [b][foo 2], [foo](https://example.com/y), \
+                 [foo](https://example.com/z) and [foo](https://example.com/x).\n\n\
+                 [foo 2]: https://example.com/x\n";
+    let result = parse_and_serialize_with_source(input);
+    let count = result.matches("]: https://example.com/x").count();
+    assert_eq!(
+        count, 1,
+        "the occupied variant's target should keep a single definition, got:\n{}",
+        result
+    );
+    assert!(
+        result.contains("[foo][foo 2]"),
+        "the later link should reuse the existing variant, got:\n{}",
+        result
+    );
+    let result2 = parse_and_serialize_with_source(&result);
+    assert_eq!(result, result2, "should be idempotent, got:\n{}", result2);
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1685,3 +1685,34 @@ anchor_align = 0
         assert_eq!(result, "Title {#t}\n==========\n");
     }
 }
+
+/// Test that links sharing the same text but different destinations keep
+/// their own destinations.
+///
+/// See also <https://github.com/dahlia/hongdown/issues/26>.
+#[test]
+fn test_duplicate_link_text_preserves_each_destination() {
+    let input = r#" -  Read [guide](https://example.com/first).
+ -  Read [guide](https://example.com/second).
+"#;
+
+    let options = Options::default();
+    let result = format(input, &options).unwrap();
+
+    assert!(
+        result.contains("[guide]: https://example.com/first"),
+        "First destination should be preserved, got:\n{}",
+        result
+    );
+    assert!(
+        result.contains("[guide 2]: https://example.com/second"),
+        "Second destination should be preserved, got:\n{}",
+        result
+    );
+
+    let second_pass = format(&result, &options).unwrap();
+    assert_eq!(
+        result, second_pass,
+        "Distinct reference labels should be idempotent"
+    );
+}


### PR DESCRIPTION
Fixes <https://github.com/dahlia/hongdown/issues/26>.

Hongdown derives a reference label from the link text, so `[guide](…/first)` and `[guide](…/second)` both wanted the label `guide`. The second definition overwrote the first, and formatting silently changed where the first link pointed.


Why registration comes first
----------------------------

The serializer wrote a link's output and registered its definition afterwards. That ordering is why the bug was reachable at all: by the time the collision became visible, `[guide]` was already in the buffer, so no emit site could respond to it.

`Serializer::register_reference()` takes over from `Serializer::add_reference()` and returns the spelling the caller has to emit. The helpers in *src/serializer/link.rs* and *src/serializer/inline.rs* call it before they choose between shortcut, collapsed and full reference syntax, which is what lets a collision force the full form.

Forcing it matters. A renumbered link has to come out as `[guide][guide 2]`, because the shortcut and collapsed forms re-derive the label from the link text: written as `[guide]`, a renumbered link would collide again on the next run, be renumbered again, and grow a suffix on every pass. The full form carries the decision into the document, and that is what makes the output settle after one pass.

A label is shared only when the whole target matches, URL and title both. Two links that differ only in title still need two definitions, since a title is part of what a definition carries.


Matching labels the way the parser does
---------------------------------------

comrak resolves a reference label by collapsing runs of whitespace and then applying Unicode default case folding. Folding is not lowercasing, so `[Straße]` and `[STRASSE]` are one label to the parser, and emitting a definition for each meant the second was ignored and both links resolved to the first URL. `normalize_reference_key()` mirrors both steps and folds with `caseless::default_case_fold_str()`, the function comrak's own `normalize_label()` calls. `caseless` was already in the tree through comrak, so this promotes a transitive dependency rather than adding one.

`emitted_references` needed the same treatment for a different reason. Holding only labels, it could not tell a definition already emitted for this target from one emitted for a different target under the same label, and it dropped the latter at flush time, leaving a later section's link resolving to an earlier section's URL. It stores the `ReferenceLink` now, and because collisions are settled when the label is registered, that flush-time drop is no longer reachable.


Generated labels have to stay parseable
---------------------------------------

comrak rejects a reference label longer than 1000 bytes, and rejection is not graceful: the link decays into literal text and loses its destination outright, which is worse than the bug being fixed. Numbered labels are truncated at a character boundary to fit.

`truncate_reference_label_base()` reserves room for the largest `u32` suffix rather than for the suffix actually being appended. My first attempt sized the cut to the suffix, which meant the truncated base shifted as the number gained a digit. Two long labels that shorten to the same prefix could then allocate over each other, because their variants moved between namespaces underneath them. Reserving a fixed amount keeps every variant of a label in one namespace.


Allocation cost
---------------

Searching upward from 2 on each collision, which is what this branch did at first, is quadratic. A document with 10,000 same-text links took 4.6s in a release build, on input that is odd but not adversarial, so it seemed worth fixing before it landed rather than after.

Each namespace keeps a cursor now, sound because a taken label is never released. A cursor on its own would regress deduplication: a target reappearing after its variant was allocated would be handed a fresh one and pick up a second, redundant definition. A map from namespace, URL and title to the variant already issued preserves it, and the scan records the occupants of the variants it steps over so they stay reachable once the cursor has passed them. The same 10,000 links now take 0.04s.


What I checked
--------------

Seventeen unit tests and one integration test. They cover deduplication by target and by title; collisions across sections, inside footnotes, in headings, between an image and a link, against a hand-written label, between numeric labels, and under case folding; the 1000-byte limit; and reuse of a numbered label. Eight of them format twice and compare, including the near-limit case where a mistake would otherwise be invisible.

That brings the repository to 717 Rust unit tests and 79 integration tests, alongside 30 WASM cases and 9 for the VS Code extension.

Formatting every Markdown file in the repository produced no changes. By hand I also checked that a `[guide 2]` already present in the source is respected, so the collision skips to `guide 3`.


Left alone deliberately
-----------------------

A generated label registered before a hand-written one will renumber the hand-written label. The output stays correct and idempotent, but the diff is noisier than it needs to be. Fixing it properly wants a pre-pass reserving authored labels before any generated one is issued, which is more machinery than this bug justifies.

Two neighboring bugs turned up while testing and reproduce identically without this patch, so they are filed separately rather than folded in: reference definitions inside a `hongdown-disable` region are dropped (https://github.com/dahlia/hongdown/issues/27), and consecutive whitespace in link text needs two passes to settle (https://github.com/dahlia/hongdown/issues/28).
