### PR TITLE
Preserve reference definitions around disabled regions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,16 @@ To be released.
     when it directly followed front matter, and lost the blank line entirely
     when the only thing above it was a reference definition.  [[#27], [#32]]
 
+ -  Fixed a bug where a block whose formatting was skipped by
+    `<!-- hongdown-disable-next-line -->` or
+    `<!-- hongdown-disable-next-section -->` was copied from where its content
+    begins rather than from the start of its lines, losing the indentation and
+    the list or blockquote markers before it.  An indented code block came out
+    as a paragraph, and a reference definition the parser had taken out of a
+    list item was dropped altogether.  Such a block also gained a blank line on
+    every run, so `--check` reported a file `--write` had just written.
+    [[#32]]
+
  -  Fixed a bug where a reference label holding a bracket escaped with a
     backslash, as in `[a\]b]`, was cut short at that bracket.  The link was
     given a label naming no definition, and the definition itself was written

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,8 +27,39 @@ To be released.
     folding applied, the same way the underlying parser resolves them.
     [[#26], [#29]]
 
+ -  Fixed a bug where a reference definition placed inside a
+    `<!-- hongdown-disable -->` region was dropped, leaving the region's links
+    pointing at nothing.  Since the loss was stable across runs, `--check`
+    never reported the damaged file afterwards.  The region between the two
+    directives is now copied from the source in one piece instead of being
+    rebuilt block by block, so its reference definitions survive, as do its
+    footnote definitions, interior blank lines, and indentation.  (The blank
+    line separating the region from the directives around it is still
+    normalized to exactly one.)  [[#27], [#32]]
+
+ -  Fixed a bug where a reference definition was dropped when the only links
+    using it sat in a region that skips formatting.  Those links are copied
+    from the source and never registered the definition they depend on, which
+    silently broke reference-style badges under `<!-- hongdown-disable -->`,
+    `<!-- hongdown-disable-next-line -->`,
+    `<!-- hongdown-disable-next-section -->`, and
+    `<!-- hongdown-disable-file -->`.  [[#27], [#32]]
+
+ -  Fixed a bug where a link inside a region that skips formatting could have
+    its destination changed by a link outside it.  A copied link keeps the
+    label the source gave it, so when both wanted the same label for different
+    destinations the copied one silently lost its target.  The formatted link,
+    which can be given a derived label such as `[guide][guide 2]`, now yields
+    instead.  [[#27], [#32]]
+
+ -  Fixed a bug where a directive comment gained an extra blank line above it
+    when it directly followed front matter, and lost the blank line entirely
+    when the only thing above it was a reference definition.  [[#27], [#32]]
+
 [#26]: https://github.com/dahlia/hongdown/issues/26
+[#27]: https://github.com/dahlia/hongdown/issues/27
 [#29]: https://github.com/dahlia/hongdown/pull/29
+[#32]: https://github.com/dahlia/hongdown/pull/32
 
 
 Version 0.5.1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,6 +56,12 @@ To be released.
     when it directly followed front matter, and lost the blank line entirely
     when the only thing above it was a reference definition.  [[#27], [#32]]
 
+ -  Fixed a bug where a reference label holding a bracket escaped with a
+    backslash, as in `[a\]b]`, was cut short at that bracket.  The link was
+    given a label naming no definition, and the definition itself was written
+    out cut short too, so the next run no longer read it as a definition at
+    all.  [[#32]]
+
 [#26]: https://github.com/dahlia/hongdown/issues/26
 [#27]: https://github.com/dahlia/hongdown/issues/27
 [#29]: https://github.com/dahlia/hongdown/pull/29

--- a/STYLE.md
+++ b/STYLE.md
@@ -704,6 +704,63 @@ The HTML specification defines this behavior.
 ~~~~
 
 
+Disabled regions
+----------------
+
+Formatting can be turned off for part of a document with the HTML comment
+directives listed in the *[README](./README.md)*.  What follows describes what
+is preserved where they apply.
+
+### Verbatim content
+
+Content whose formatting is disabled is copied from the source as it stands,
+including its indentation, the blank lines within it, and any reference or
+footnote definition written inside it:
+
+~~~~ markdown
+<!-- hongdown-disable -->
+
+Kept    exactly   as written, [guide] and all.
+
+[guide]: https://example.com/guide
+
+<!-- hongdown-enable -->
+~~~~
+
+The blank line between a directive comment and the content beside it is
+normalized to one.  Everything between them is left alone.
+
+*Rationale*: A reference definition is not a node of its own in the parsed
+document, so a region rebuilt element by element loses one.  Copying the
+region's source keeps whatever it holds.
+
+### Definitions a disabled region needs
+
+A link that is copied keeps the label the source gave it, so a definition it
+depends on is kept even where nothing else refers to it, and stays where the
+source put it:
+
+~~~~ markdown
+<!-- hongdown-disable -->
+
+[![Build status][badge]][ci]
+
+<!-- hongdown-enable -->
+
+[badge]: https://example.com/badge.svg
+[ci]: https://example.com/ci
+~~~~
+
+A label a disabled region defines belongs to that region.  Where a formatted
+link would otherwise take it for a different target, that link is given a
+numbered label instead, as in *[Distinct labels for distinct
+targets](#distinct-labels-for-distinct-targets)*.
+
+*Rationale*: A copied link cannot be relabelled without changing text that is
+meant to be preserved, and a definition inside the region defines its label for
+the whole document.
+
+
 MDX
 ---
 

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -15,9 +15,10 @@ use super::wrap;
 ///
 /// A blockquote prefix may precede the label, since a definition written inside
 /// a blockquote still defines a document-wide label.  A list marker may not:
-/// `- [x]: done` is a task list item.
+/// `- [x]: done` is a task list item.  The label runs to the first `]` that a
+/// backslash does not escape, so that `[a\]b]` is read whole.
 static REFERENCE_DEFINITION: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^[\s>]*\[([^\]]+)\]:").unwrap());
+    LazyLock::new(|| Regex::new(r"^[\s>]*\[((?:[^\]\\]|\\.)+)\]:").unwrap());
 
 /// A reference definition that a link preserved verbatim depends on.
 struct VerbatimReference {

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -249,6 +249,15 @@ impl<'a> Serializer<'a> {
                             // back to emitting its blocks one by one.
                             self.skip_mode = FormatSkipMode::Disabled;
                         } else {
+                            // A directive naming nouns names them for the
+                            // headings after the region as much as for the ones
+                            // before it, which is what it did when the region
+                            // was emitted a node at a time.  Its comment is
+                            // part of the copy; only its effect is left to
+                            // carry out.
+                            for skipped in &children[i + 1..region_last] {
+                                self.apply_noun_directive(skipped);
+                            }
                             self.output.push('\n');
                             self.output.push_str(&region);
                             self.output.push('\n');
@@ -383,6 +392,21 @@ impl<'a> Serializer<'a> {
 
         // Output trailing HTML blocks after references and footnotes
         self.output_trailing_html_blocks(&children, trailing_html_start);
+    }
+
+    /// Take up the nouns a node names, where the node is a directive naming
+    /// any.  Whether the node's own text is formatted or copied has no bearing
+    /// on the headings it speaks for.
+    fn apply_noun_directive<'b>(&mut self, node: &'b AstNode<'b>) {
+        let directive = match &node.data.borrow().value {
+            NodeValue::HtmlBlock(html_block) => Directive::parse(&html_block.literal),
+            _ => None,
+        };
+        match directive {
+            Some(Directive::ProperNouns(nouns)) => self.directive_proper_nouns.extend(nouns),
+            Some(Directive::CommonNouns(nouns)) => self.directive_common_nouns.extend(nouns),
+            _ => {}
+        }
     }
 
     /// Find the index of the `hongdown-enable` directive that closes the

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -527,11 +527,7 @@ impl<'a> Serializer<'a> {
             } else {
                 sourcepos.start.line
             };
-            for line in start..=sourcepos.end.line {
-                if let Some(marked) = in_leaf_block.get_mut(line - 1) {
-                    *marked = true;
-                }
-            }
+            Self::mark_lines(&[(start, sourcepos.end.line)], in_leaf_block);
             return;
         }
         drop(data);

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -37,14 +37,19 @@ impl<'a> Serializer<'a> {
         // definitions, comments — travels with the copy and must not be
         // emitted a second time from elsewhere.
         let verbatim_ranges = self.collect_verbatim_line_ranges(&children);
-        // Every range whose content keeps its source text, which is the wider
-        // set: it also covers the blocks the skip modes emit one by one.
-        let disabled_ranges = Self::collect_disabled_line_ranges(node);
+        // Everything copied from the source, whether as a whole region or a
+        // block at a time.  A block's span reaches back over any definition
+        // consumed at its head, so those copies carry definitions of their own.
+        // A document is largely copied blocks where it is copied at all, so
+        // this is a line-indexed table rather than a list of spans to walk.
+        let mut copied_lines = vec![false; self.source_lines.len()];
+        Self::mark_lines(&verbatim_ranges, &mut copied_lines);
+        Self::mark_copied_block_lines(&children, &mut copied_lines);
 
-        // Both analyses below cost a pass over the document and only say
+        // The analysis below costs a pass over the document and only says
         // something about content that keeps its source text, so a document
-        // without the directives that produce such content skips them.
-        if !verbatim_ranges.is_empty() {
+        // that copies none skips it.
+        if copied_lines.contains(&true) {
             let mut in_leaf_block = vec![false; self.source_lines.len()];
             Self::mark_leaf_block_lines(node, &self.source_lines, &mut in_leaf_block);
             for (label, lines) in
@@ -58,18 +63,18 @@ impl<'a> Serializer<'a> {
                 // after it.
                 let mut lines = lines.into_iter();
                 let winner = lines.next().unwrap_or_default();
-                if Self::is_line_in_ranges(winner, &verbatim_ranges) {
-                    self.verbatim_reference_labels.insert(label);
-                } else if lines.any(|line| Self::is_line_in_ranges(line, &verbatim_ranges)) {
-                    self.shadowed_reference_labels.insert(label);
+                if Self::is_line_marked(winner, &copied_lines) {
+                    self.verbatim_reference_labels.insert(label.clone());
+                } else if lines.any(|line| Self::is_line_marked(line, &copied_lines)) {
+                    self.shadowed_reference_labels.insert(label.clone());
                 }
+                self.reference_definition_lines.insert(label, winner);
             }
-        }
-        if !disabled_ranges.is_empty() {
-            self.collect_verbatim_reference_claims(node, &disabled_ranges);
+            self.collect_verbatim_reference_claims(node, &copied_lines);
         }
 
         // Check for undefined reference links using AST
+        let disabled_ranges = Self::collect_disabled_line_ranges(node);
         self.check_undefined_references_ast(node, &disabled_ranges);
 
         // First pass: collect all footnote reference lines
@@ -131,7 +136,7 @@ impl<'a> Serializer<'a> {
                         // Definitions that appear before the directive should stay before it.
                         let directive_line = child.data.borrow().sourcepos.start.line;
                         self.flush_footnotes_before(Some(directive_line));
-                        self.flush_references();
+                        self.flush_references_before(Some(directive_line));
                         self.flush_footnote_references_before(Some(directive_line));
 
                         // Output the directive comment, then output remaining content as-is.
@@ -156,7 +161,7 @@ impl<'a> Serializer<'a> {
                         // Definitions that appear before the directive should stay before it.
                         let directive_line = child.data.borrow().sourcepos.start.line;
                         self.flush_footnotes_before(Some(directive_line));
-                        self.flush_references();
+                        self.flush_references_before(Some(directive_line));
                         self.flush_footnote_references_before(Some(directive_line));
 
                         self.skip_mode = FormatSkipMode::NextBlock;
@@ -172,7 +177,7 @@ impl<'a> Serializer<'a> {
                         // Definitions that appear before the directive should stay before it.
                         let directive_line = child.data.borrow().sourcepos.start.line;
                         self.flush_footnotes_before(Some(directive_line));
-                        self.flush_references();
+                        self.flush_references_before(Some(directive_line));
                         self.flush_footnote_references_before(Some(directive_line));
 
                         self.skip_mode = FormatSkipMode::UntilSection;
@@ -230,7 +235,7 @@ impl<'a> Serializer<'a> {
                         // Definitions that appear before the directive should stay before it.
                         let directive_line = child.data.borrow().sourcepos.start.line;
                         self.flush_footnotes_before(Some(directive_line));
-                        self.flush_references();
+                        self.flush_references_before(Some(directive_line));
                         self.flush_footnote_references_before(Some(directive_line));
 
                         // Output the directive comment.  A definition flushed
@@ -300,10 +305,10 @@ impl<'a> Serializer<'a> {
 
             if is_h2_or_h3 && i > 0 {
                 // Get the source line of the heading to flush only earlier footnotes
-                let heading_line = child.data.borrow().sourcepos.start.line;
+                let heading_line = self.section_boundary_line(child);
                 // Footnotes come before link reference definitions
                 self.flush_footnotes_before(Some(heading_line));
-                self.flush_references();
+                self.flush_references_before(Some(heading_line));
                 self.flush_footnote_references_before(Some(heading_line));
             }
 
@@ -474,13 +479,22 @@ impl<'a> Serializer<'a> {
         );
         if !holds_blocks {
             let sourcepos = data.sourcepos;
-            let start = if let NodeValue::Paragraph = &data.value {
+            // A setext heading is built from a paragraph and swallows a
+            // consumed head the same way, with its underline as one more line
+            // of content below the text.
+            let underline_lines = match &data.value {
+                NodeValue::Paragraph => Some(0),
+                NodeValue::Heading(heading) if heading.setext => Some(1),
+                _ => None,
+            };
+            let start = if let Some(underline_lines) = underline_lines {
                 drop(data);
-                Self::paragraph_content_start(
+                Self::leaf_content_start(
                     node,
                     source_lines,
                     sourcepos.start.line,
                     sourcepos.end.line,
+                    underline_lines,
                 )
             } else {
                 sourcepos.start.line
@@ -499,28 +513,30 @@ impl<'a> Serializer<'a> {
         }
     }
 
-    /// The first line of a paragraph's own content.
+    /// The first line of a block's own content, for the blocks that swallow a
+    /// consumed head: a paragraph, and the setext heading built from one.
     ///
-    /// Definitions are consumed from the head of a paragraph, and the node
+    /// Definitions are consumed from the head of such a block, and the node
     /// keeps the lines they occupied, so those lines have to stay visible to
-    /// the definition scanner while the paragraph's own lines do not.
+    /// the definition scanner while the block's own lines do not.
     ///
     /// Two readings bound where the content starts, and a line is left visible
     /// only where they agree.  The content sits at the end of the span, one
-    /// line per break it contains, which misjudges a paragraph whose inline
-    /// spans lines without a break node, such as a code span or display math
-    /// holding a newline.  A consumed head is also made of definitions, so the
-    /// first line that does not begin one ends it, which instead misjudges a
-    /// paragraph opening with something that merely resembles a definition.
-    /// Neither mistake survives the other.
-    fn paragraph_content_start<'b>(
+    /// line per break it contains plus any `underline_lines` below it, which
+    /// misjudges a block whose inline spans lines without a break node, such as
+    /// a code span or display math holding a newline.  A consumed head is also
+    /// made of definitions, so the first line that does not begin one ends it,
+    /// which instead misjudges a block opening with something that merely
+    /// resembles a definition.  Neither mistake survives the other.
+    fn leaf_content_start<'b>(
         node: &'b AstNode<'b>,
         source_lines: &[&str],
         start_line: usize,
         end_line: usize,
+        underline_lines: usize,
     ) -> usize {
         let by_breaks = end_line
-            .saturating_sub(Self::count_line_breaks(node))
+            .saturating_sub(Self::count_line_breaks(node) + underline_lines)
             .max(start_line);
 
         let mut by_definitions = start_line;
@@ -552,6 +568,111 @@ impl<'a> Serializer<'a> {
             _ => 0,
         };
         own + node.children().map(Self::count_line_breaks).sum::<usize>()
+    }
+
+    /// The line at which a heading opens its section, for deciding what came
+    /// before it.
+    ///
+    /// A setext heading reports the lines of any definition consumed at its
+    /// head as its own, so its reported start sits on top of content that in
+    /// fact precedes it.  Its content start is where the section really begins.
+    fn section_boundary_line<'b>(&self, node: &'b AstNode<'b>) -> usize {
+        let (setext, sourcepos) = {
+            let data = node.data.borrow();
+            let setext = matches!(&data.value, NodeValue::Heading(heading) if heading.setext);
+            (setext, data.sourcepos)
+        };
+        if !setext {
+            return sourcepos.start.line;
+        }
+        Self::leaf_content_start(
+            node,
+            &self.source_lines,
+            sourcepos.start.line,
+            sourcepos.end.line,
+            1,
+        )
+    }
+
+    /// Mark every line of the given ranges in a line-indexed table.
+    fn mark_lines(ranges: &[(usize, usize)], lines: &mut [bool]) {
+        for (start, end) in ranges {
+            for line in (*start).max(1)..=*end {
+                if let Some(marked) = lines.get_mut(line - 1) {
+                    *marked = true;
+                }
+            }
+        }
+    }
+
+    /// Whether a line is marked in a line-indexed table.
+    fn is_line_marked(line: usize, lines: &[bool]) -> bool {
+        line > 0 && lines.get(line - 1).copied().unwrap_or(false)
+    }
+
+    /// Mark the source lines of the blocks the skip modes copy one at a time,
+    /// as opposed to the regions copied whole by
+    /// [`Self::collect_verbatim_line_ranges`], whose lines `copied_lines`
+    /// already carries.
+    ///
+    /// A block is copied by its span, which reaches back over any definition
+    /// consumed at its head, so such a definition is carried by the copy even
+    /// though nothing else in the block refers to it.
+    ///
+    /// The modes are followed the way serialization follows them, since only
+    /// the blocks it actually copies carry anything: a footnote definition is
+    /// emitted by the footnote machinery and leaves the mode untouched, a
+    /// directive naming nouns leaves it untouched as well, and `Enable` ends a
+    /// section-wide skip just as the next section's heading does.
+    fn mark_copied_block_lines<'b>(children: &[&'b AstNode<'b>], copied_lines: &mut [bool]) {
+        let mut skip_mode = FormatSkipMode::None;
+
+        for child in children {
+            let data = child.data.borrow();
+            let sourcepos = data.sourcepos;
+
+            // What a region copies whole is already marked, and its blocks
+            // never run through the modes at all.
+            if Self::is_line_marked(sourcepos.start.line, copied_lines) {
+                continue;
+            }
+            if let NodeValue::FootnoteDefinition(_) = &data.value {
+                continue;
+            }
+            if let NodeValue::HtmlBlock(html_block) = &data.value
+                && let Some(directive) = Directive::parse(&html_block.literal)
+            {
+                match directive {
+                    Directive::DisableNextLine => skip_mode = FormatSkipMode::NextBlock,
+                    Directive::DisableNextSection => skip_mode = FormatSkipMode::UntilSection,
+                    Directive::DisableFile => break,
+                    Directive::Disable | Directive::Enable => skip_mode = FormatSkipMode::None,
+                    Directive::ProperNouns(_) | Directive::CommonNouns(_) => {}
+                }
+                continue;
+            }
+
+            let copied = match skip_mode {
+                FormatSkipMode::NextBlock => {
+                    skip_mode = FormatSkipMode::None;
+                    true
+                }
+                FormatSkipMode::UntilSection => {
+                    // The heading that opens the next section is formatted like
+                    // any other, and ends the skip.
+                    if matches!(&data.value, NodeValue::Heading(heading) if heading.level <= 2) {
+                        skip_mode = FormatSkipMode::None;
+                        false
+                    } else {
+                        true
+                    }
+                }
+                FormatSkipMode::None | FormatSkipMode::Disabled => false,
+            };
+            if copied {
+                Self::mark_lines(&[(sourcepos.start.line, sourcepos.end.line)], copied_lines);
+            }
+        }
     }
 
     /// Collect the normalized labels of the reference definitions the source
@@ -601,10 +722,10 @@ impl<'a> Serializer<'a> {
     fn collect_verbatim_reference_claims<'b>(
         &mut self,
         node: &'b AstNode<'b>,
-        disabled_ranges: &[(usize, usize)],
+        copied_lines: &[bool],
     ) {
         for child in node.children() {
-            self.collect_verbatim_reference_claims(child, disabled_ranges);
+            self.collect_verbatim_reference_claims(child, copied_lines);
         }
 
         let (target, line) = {
@@ -619,7 +740,7 @@ impl<'a> Serializer<'a> {
         };
 
         if let Some((url, title)) = target
-            && Self::is_line_in_ranges(line, disabled_ranges)
+            && Self::is_line_marked(line, copied_lines)
             && let Some(label) = self.verbatim_reference_label(node)
         {
             self.verbatim_reference_claims

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -214,7 +214,12 @@ impl<'a> Serializer<'a> {
                         let enable_index = Self::find_enable_directive(&children, i);
                         let region_last = enable_index.unwrap_or(children.len());
                         let region_start = child.data.borrow().sourcepos.end.line + 1;
+                        // A directive disabling the file, written inside the
+                        // region, disables it past the region's own end, so the
+                        // copy runs to the last line and nothing follows it.
+                        let disables_file = Self::disables_file(&children[i + 1..region_last]);
                         let region_end = match enable_index {
+                            Some(_) if disables_file => self.source_lines.len(),
                             Some(j) => children[j]
                                 .data
                                 .borrow()
@@ -261,6 +266,9 @@ impl<'a> Serializer<'a> {
                             self.output.push('\n');
                             self.output.push_str(&region);
                             self.output.push('\n');
+                            if disables_file {
+                                return;
+                            }
                             skip_until = region_last;
                         }
                         continue;
@@ -394,6 +402,19 @@ impl<'a> Serializer<'a> {
         self.output_trailing_html_blocks(&children, trailing_html_start);
     }
 
+    /// Whether any of these nodes is a directive disabling the file, which
+    /// leaves the rest of it as it stands wherever the directive is written,
+    /// the end of an enclosing region included.
+    fn disables_file<'b>(children: &[&'b AstNode<'b>]) -> bool {
+        children.iter().any(|child| {
+            matches!(
+                &child.data.borrow().value,
+                NodeValue::HtmlBlock(html_block)
+                    if Directive::parse(&html_block.literal) == Some(Directive::DisableFile)
+            )
+        })
+    }
+
     /// Take up the nouns a node names, where the node is a directive naming
     /// any.  Whether the node's own text is formatted or copied has no bearing
     /// on the headings it speaks for.
@@ -450,6 +471,14 @@ impl<'a> Serializer<'a> {
                 }
                 Some(Directive::Disable) => {
                     let enable_index = Self::find_enable_directive(children, i);
+                    let region_last = enable_index.unwrap_or(children.len());
+                    // A directive disabling the file leaves everything after it
+                    // as it stands, which reaches past the end of the region it
+                    // is written in.
+                    if Self::disables_file(&children[i + 1..region_last]) {
+                        ranges.push((start_line, last_line));
+                        break;
+                    }
                     let end_line = match enable_index {
                         Some(j) => children[j]
                             .data
@@ -462,7 +491,7 @@ impl<'a> Serializer<'a> {
                     };
                     ranges.push((start_line, end_line));
                     // Nested directives inside the region are part of the copy.
-                    i = enable_index.unwrap_or(children.len());
+                    i = region_last;
                 }
                 _ => {}
             }

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -349,8 +349,22 @@ impl<'a> Serializer<'a> {
                     continue;
                 }
 
-                // Output the original source
-                if let Some(source) = self.extract_source(child) {
+                // Output the original source, by whole lines.  A block's span
+                // begins at its content, past the indentation and the markers
+                // of whatever holds it, and a copy that started there would
+                // lose them — including a reference definition the parser took
+                // out of a list item, which the span then leaves behind.  It is
+                // also what the copy is taken to be everywhere else: the lines
+                // it occupies, which is what marks them as copied.
+                let sourcepos = child.data.borrow().sourcepos;
+                let source = self
+                    .extract_source_lines(sourcepos.start.line, sourcepos.end.line)
+                    // A block's span may reach over the blank lines below it,
+                    // which the separator between blocks supplies again; keeping
+                    // both would add one more on every run.
+                    .map(|source| Self::trim_blank_lines(&source))
+                    .filter(|source| !source.is_empty());
+                if let Some(source) = source {
                     self.output.push_str(&source);
                     self.output.push('\n');
                 } else {

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -41,25 +41,33 @@ impl<'a> Serializer<'a> {
         // set: it also covers the blocks the skip modes emit one by one.
         let disabled_ranges = Self::collect_disabled_line_ranges(node);
 
-        let mut leaf_block_ranges = Vec::new();
-        Self::collect_leaf_block_line_ranges(node, &self.source_lines, &mut leaf_block_ranges);
-        for (label, lines) in
-            Self::collect_reference_definition_lines(&self.source_lines, &leaf_block_ranges)
-        {
-            // Only the first definition of a label counts, the way CommonMark
-            // resolves it.  When it is the one the copy carries, the copy also
-            // defines it; when a *later* one is, the copy merely repeats a
-            // definition that has no effect where it stands but would take
-            // effect if the winning one were emitted after it.
-            let mut lines = lines.into_iter();
-            let winner = lines.next().unwrap_or_default();
-            if Self::is_line_in_ranges(winner, &verbatim_ranges) {
-                self.verbatim_reference_labels.insert(label);
-            } else if lines.any(|line| Self::is_line_in_ranges(line, &verbatim_ranges)) {
-                self.shadowed_reference_labels.insert(label);
+        // Both analyses below cost a pass over the document and only say
+        // something about content that keeps its source text, so a document
+        // without the directives that produce such content skips them.
+        if !verbatim_ranges.is_empty() {
+            let mut in_leaf_block = vec![false; self.source_lines.len()];
+            Self::mark_leaf_block_lines(node, &self.source_lines, &mut in_leaf_block);
+            for (label, lines) in
+                Self::collect_reference_definition_lines(&self.source_lines, &in_leaf_block)
+            {
+                // Only the first definition of a label counts, the way
+                // CommonMark resolves it.  When it is the one the copy carries,
+                // the copy also defines it; when a *later* one is, the copy
+                // merely repeats a definition that has no effect where it
+                // stands but would take effect if the winning one were emitted
+                // after it.
+                let mut lines = lines.into_iter();
+                let winner = lines.next().unwrap_or_default();
+                if Self::is_line_in_ranges(winner, &verbatim_ranges) {
+                    self.verbatim_reference_labels.insert(label);
+                } else if lines.any(|line| Self::is_line_in_ranges(line, &verbatim_ranges)) {
+                    self.shadowed_reference_labels.insert(label);
+                }
             }
         }
-        self.collect_verbatim_reference_claims(node, &disabled_ranges);
+        if !disabled_ranges.is_empty() {
+            self.collect_verbatim_reference_claims(node, &disabled_ranges);
+        }
 
         // Check for undefined reference links using AST
         self.check_undefined_references_ast(node, &disabled_ranges);
@@ -431,17 +439,22 @@ impl<'a> Serializer<'a> {
         ranges
     }
 
-    /// Collect the source line ranges the document's leaf blocks occupy.
+    /// Mark, in a line-indexed table, the source lines the document's leaf
+    /// blocks occupy.
     ///
     /// A reference definition is consumed by the parser and belongs to no node,
-    /// so it can only live in the gaps these ranges leave: a line inside a leaf
-    /// block is that block's content, however much it may resemble one.  Only
-    /// blocks that can hold other blocks are descended into, since a definition
-    /// may well sit between the children of a blockquote or a list item.
-    fn collect_leaf_block_line_ranges<'b>(
+    /// so it can only live in the gaps this leaves: a line inside a leaf block
+    /// is that block's content, however much it may resemble one.  Only blocks
+    /// that can hold other blocks are descended into, since a definition may
+    /// well sit between the children of a blockquote or a list item.
+    ///
+    /// A table rather than a list of ranges keeps the lookup constant-time; a
+    /// document is mostly leaf blocks, so scanning a range list per line would
+    /// cost time quadratic in the number of blocks.
+    fn mark_leaf_block_lines<'b>(
         node: &'b AstNode<'b>,
         source_lines: &[&str],
-        ranges: &mut Vec<(usize, usize)>,
+        in_leaf_block: &mut [bool],
     ) {
         let data = node.data.borrow();
         let holds_blocks = matches!(
@@ -472,13 +485,17 @@ impl<'a> Serializer<'a> {
             } else {
                 sourcepos.start.line
             };
-            ranges.push((start, sourcepos.end.line));
+            for line in start..=sourcepos.end.line {
+                if let Some(marked) = in_leaf_block.get_mut(line - 1) {
+                    *marked = true;
+                }
+            }
             return;
         }
         drop(data);
 
         for child in node.children() {
-            Self::collect_leaf_block_line_ranges(child, source_lines, ranges);
+            Self::mark_leaf_block_lines(child, source_lines, in_leaf_block);
         }
     }
 
@@ -542,22 +559,21 @@ impl<'a> Serializer<'a> {
     ///
     /// The parser resolves references through a map it does not expose, so the
     /// definitions have to be recognized from the source.  What makes that
-    /// reliable is `leaf_block_ranges`: everything the parser did turn into a
-    /// block is excluded, and a line the parser kept out of every block while
-    /// it looks like a definition is one.  Prose that merely resembles a
+    /// reliable is `in_leaf_block`: everything the parser did turn into a block
+    /// is excluded, and a line the parser kept out of every block while it
+    /// looks like a definition is one.  Prose that merely resembles a
     /// definition, in a paragraph, a code block, raw HTML or a heading, is part
     /// of its block and never reaches this test.
-    ///
     fn collect_reference_definition_lines(
         source_lines: &[&str],
-        leaf_block_ranges: &[(usize, usize)],
+        in_leaf_block: &[bool],
     ) -> std::collections::HashMap<String, Vec<usize>> {
         let mut definitions: std::collections::HashMap<String, Vec<usize>> =
             std::collections::HashMap::new();
 
         for (i, line) in source_lines.iter().enumerate() {
             let line_number = i + 1;
-            if Self::is_line_in_ranges(line_number, leaf_block_ranges) {
+            if in_leaf_block.get(i).copied().unwrap_or(false) {
                 continue;
             }
             if let Some(caps) = REFERENCE_DEFINITION.captures(line)

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -11,14 +11,29 @@ use super::escape;
 use super::state::{Directive, FormatSkipMode, ReferenceLink, normalize_reference_key};
 use super::wrap;
 
-/// Matches a line that begins a reference definition, capturing its label.
+/// Matches whatever container markers open the line a reference definition
+/// starts on.
 ///
-/// A blockquote prefix may precede the label, since a definition written inside
-/// a blockquote still defines a document-wide label.  A list marker may not:
-/// `- [x]: done` is a task list item.  The label runs to the first `]` that a
-/// backslash does not escape, so that `[a\]b]` is read whole.
-static REFERENCE_DEFINITION: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"^[\s>]*\[((?:[^\]\\]|\\.)+)\]:").unwrap());
+/// A definition keeps defining a document-wide label wherever it is written, so
+/// a blockquote marker or a list marker may stand before it.  `- [x]: done` is
+/// no task list item — the colon rules that out — and its label is as
+/// document-wide as any other.
+static DEFINITION_PREFIX: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(?:[ \t>]|(?:[-*+]|\d{1,9}[.)])[ \t]+)*").unwrap());
+
+/// Matches the container markers a definition's later lines carry.
+///
+/// Only a blockquote marks each of its lines; a list marks the first and
+/// indents the rest.  So a list marker below a definition's first line opens an
+/// item of its own, which ends the definition rather than continuing it.
+static CONTINUATION_PREFIX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[ \t>]*").unwrap());
+
+/// Matches a list marker that opens a block in the middle of one.
+///
+/// A bullet does so wherever it stands, but an ordered marker only where it
+/// numbers the list from one: `2.` below a line goes on reading as part of it.
+static LIST_MARKER: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^(?:[-*+]|1[.)])[ \t]").unwrap());
 
 /// A reference definition that a link preserved verbatim depends on.
 struct VerbatimReference {
@@ -515,51 +530,13 @@ impl<'a> Serializer<'a> {
             .max(start_line);
 
         let mut by_definitions = start_line;
-        while by_definitions < end_line {
-            let Some(line) = source_lines.get(by_definitions - 1) else {
-                break;
-            };
-            let Some(matched) = REFERENCE_DEFINITION.find(line) else {
-                break;
-            };
-            by_definitions += 1;
-            // A definition may be written over several lines: its destination
-            // on the line below the label, and a title after the destination or
-            // on a line of its own below it, running on further still.  The
-            // definitions after it sit beneath all of that, so the head reaches
-            // over it to find them.
-            let mut rest = &line[matched.end()..];
-            if rest.trim().is_empty() && by_definitions < end_line {
-                rest = source_lines.get(by_definitions - 1).copied().unwrap_or("");
-                by_definitions += 1;
-            }
-            let Some(title) = Self::title_after_destination(rest) else {
-                // The destination is malformed, so nothing here is a definition
-                // to reach over.
-                break;
-            };
-            let mut closing = Self::unclosed_delimiter_in(title);
-            if title.trim().is_empty()
-                && by_definitions < end_line
-                && let Some(below) = source_lines.get(by_definitions - 1)
-                && Self::starts_title(below)
-            {
-                by_definitions += 1;
-                closing = Self::unclosed_delimiter_in(below);
-            }
-            if let Some(closing) = closing {
-                // The delimiter that opened the title is what closes it, however
-                // many lines later, and one the source escapes closes nothing.
-                while by_definitions < end_line {
-                    let line = source_lines.get(by_definitions - 1).copied().unwrap_or("");
-                    by_definitions += 1;
-                    if Self::contains_unescaped(line, closing) {
-                        break;
-                    }
-                }
-            }
+        // A consumed head is made of definitions, each of which may take
+        // several lines; the head ends where one no longer begins.
+        while let Some((_, next)) =
+            Self::read_reference_definition(source_lines, by_definitions, end_line)
+        {
+            by_definitions = next;
         }
-
         by_breaks.min(by_definitions)
     }
 
@@ -629,6 +606,110 @@ impl<'a> Serializer<'a> {
                 None => "",
             }),
         }
+    }
+
+    /// Read the reference definition that begins on line `start`, returning its
+    /// label and the line after the last one it occupies.  Lines are 1-indexed,
+    /// and the definition may not reach `limit`.
+    ///
+    /// A definition can be written over several lines in every part of it: the
+    /// label may break across lines, the destination may sit below the label,
+    /// and a title may follow the destination or begin on a line of its own and
+    /// run on until its delimiter closes.  Reading all of that in one place is
+    /// what keeps the two callers agreeing on where a definition ends: one
+    /// walks the definitions a paragraph swallowed at its head, the other the
+    /// definitions a document carries between its blocks.
+    fn read_reference_definition(
+        source_lines: &[&str],
+        start: usize,
+        limit: usize,
+    ) -> Option<(String, usize)> {
+        if start >= limit {
+            return None;
+        }
+        let mut rest =
+            Self::strip_definition_prefix(source_lines.get(start - 1)?).strip_prefix('[')?;
+        let mut line = start;
+
+        // The label, which runs to the first `]` a backslash does not escape,
+        // however many lines below that is.
+        let mut label = String::new();
+        let after_label = loop {
+            match Self::find_unescaped(rest, ']') {
+                Some(end) => {
+                    label.push_str(&rest[..end]);
+                    break &rest[end + 1..];
+                }
+                None => {
+                    label.push_str(rest);
+                    label.push(' ');
+                    line += 1;
+                    if line >= limit {
+                        return None;
+                    }
+                    rest = Self::strip_continuation_prefix(source_lines.get(line - 1)?)?;
+                    if rest.trim().is_empty() {
+                        return None;
+                    }
+                }
+            }
+        };
+        let mut rest = after_label.strip_prefix(':')?;
+
+        // The destination, on the label's last line or the one below it.
+        if rest.trim().is_empty() {
+            if line + 1 >= limit {
+                return Some((label, line + 1));
+            }
+            line += 1;
+            rest = Self::strip_continuation_prefix(source_lines.get(line - 1)?)?;
+        }
+
+        // The title, after the destination or on a line of its own below it.
+        let title = Self::title_after_destination(rest)?;
+        let mut closing = Self::unclosed_delimiter_in(title);
+        if title.trim().is_empty()
+            && line + 1 < limit
+            && let Some(below) = source_lines
+                .get(line)
+                .and_then(|line| Self::strip_continuation_prefix(line))
+            && Self::starts_title(below)
+        {
+            line += 1;
+            closing = Self::unclosed_delimiter_in(below);
+        }
+        if let Some(closing) = closing {
+            // The delimiter that opened the title is what closes it, however
+            // many lines later, and one the source escapes closes nothing.
+            while line + 1 < limit {
+                line += 1;
+                if Self::contains_unescaped(source_lines.get(line - 1)?, closing) {
+                    break;
+                }
+            }
+        }
+
+        Some((label, line + 1))
+    }
+
+    /// The content of a definition's first line, past the container markers
+    /// that open it.
+    fn strip_definition_prefix(line: &str) -> &str {
+        match DEFINITION_PREFIX.find(line) {
+            Some(prefix) => &line[prefix.end()..],
+            None => line,
+        }
+    }
+
+    /// The content of a line continuing a definition, past the markers of the
+    /// container it sits in.  `None` where the line opens a block of its own
+    /// instead, which ends the definition rather than continuing it.
+    fn strip_continuation_prefix(line: &str) -> Option<&str> {
+        let content = match CONTINUATION_PREFIX.find(line) {
+            Some(prefix) => &line[prefix.end()..],
+            None => line,
+        };
+        (!LIST_MARKER.is_match(content)).then_some(content)
     }
 
     /// Whether a line of its own begins a title, as one below a definition's
@@ -791,23 +872,40 @@ impl<'a> Serializer<'a> {
         let mut definitions: std::collections::HashMap<String, Vec<usize>> =
             std::collections::HashMap::new();
 
-        for (i, line) in source_lines.iter().enumerate() {
-            let line_number = i + 1;
-            if in_leaf_block.get(i).copied().unwrap_or(false) {
-                continue;
-            }
-            if let Some(caps) = REFERENCE_DEFINITION.captures(line)
-                && let Some(label) = caps.get(1)
-                // Footnote definitions are not reference definitions.
-                && !label.as_str().starts_with('^')
-            {
-                definitions
-                    .entry(normalize_reference_key(label.as_str()))
-                    .or_default()
-                    .push(line_number);
-            }
+        // A definition cannot reach into a block, so the first line of the next
+        // one is as far as it could possibly go.  Taken in one pass from the
+        // end, since a document may hold a long run of lines between blocks.
+        let end = source_lines.len() + 1;
+        let mut next_block = vec![end; source_lines.len() + 2];
+        for line in (1..=source_lines.len()).rev() {
+            next_block[line] = if in_leaf_block.get(line - 1).copied().unwrap_or(false) {
+                line
+            } else {
+                next_block[line + 1]
+            };
         }
 
+        let mut line_number = 1;
+        while line_number <= source_lines.len() {
+            if in_leaf_block.get(line_number - 1).copied().unwrap_or(false) {
+                line_number += 1;
+                continue;
+            }
+            let limit = next_block[line_number];
+            match Self::read_reference_definition(source_lines, line_number, limit) {
+                // Footnote definitions are not reference definitions.
+                Some((label, next)) => {
+                    if !label.starts_with('^') {
+                        definitions
+                            .entry(normalize_reference_key(&label))
+                            .or_default()
+                            .push(line_number);
+                    }
+                    line_number = next.max(line_number + 1);
+                }
+                None => line_number += 1,
+            }
+        }
         definitions
     }
 

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -1,5 +1,7 @@
 //! Document-level serialization logic.
 
+use std::sync::LazyLock;
+
 use comrak::nodes::{AstNode, NodeValue};
 use regex::Regex;
 use unicode_width::UnicodeWidthStr;
@@ -8,6 +10,14 @@ use super::Serializer;
 use super::escape;
 use super::state::{Directive, FormatSkipMode, ReferenceLink, normalize_reference_key};
 use super::wrap;
+
+/// Matches a line that begins a reference definition, capturing its label.
+///
+/// A blockquote prefix may precede the label, since a definition written inside
+/// a blockquote still defines a document-wide label.  A list marker may not:
+/// `- [x]: done` is a task list item.
+static REFERENCE_DEFINITION: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"^[\s>]*\[([^\]]+)\]:").unwrap());
 
 /// A reference definition that a link preserved verbatim depends on.
 struct VerbatimReference {
@@ -31,10 +41,10 @@ impl<'a> Serializer<'a> {
         // set: it also covers the blocks the skip modes emit one by one.
         let disabled_ranges = Self::collect_disabled_line_ranges(node);
 
-        let mut literal_block_ranges = Vec::new();
-        Self::collect_literal_block_line_ranges(node, &mut literal_block_ranges);
+        let mut leaf_block_ranges = Vec::new();
+        Self::collect_leaf_block_line_ranges(node, &self.source_lines, &mut leaf_block_ranges);
         for (label, lines) in
-            Self::collect_reference_definition_lines(&self.source_lines, &literal_block_ranges)
+            Self::collect_reference_definition_lines(&self.source_lines, &leaf_block_ranges)
         {
             // Only the first definition of a label counts, the way CommonMark
             // resolves it.  When it is the one the copy carries, the copy also
@@ -421,63 +431,139 @@ impl<'a> Serializer<'a> {
         ranges
     }
 
-    /// Collect the source line ranges covered by code blocks and raw HTML
-    /// blocks, whose contents are not Markdown and so may not be mistaken for
-    /// reference definitions.
-    fn collect_literal_block_line_ranges<'b>(
+    /// Collect the source line ranges the document's leaf blocks occupy.
+    ///
+    /// A reference definition is consumed by the parser and belongs to no node,
+    /// so it can only live in the gaps these ranges leave: a line inside a leaf
+    /// block is that block's content, however much it may resemble one.  Only
+    /// blocks that can hold other blocks are descended into, since a definition
+    /// may well sit between the children of a blockquote or a list item.
+    fn collect_leaf_block_line_ranges<'b>(
         node: &'b AstNode<'b>,
+        source_lines: &[&str],
         ranges: &mut Vec<(usize, usize)>,
     ) {
         let data = node.data.borrow();
-        if let NodeValue::CodeBlock(_) | NodeValue::HtmlBlock(_) = &data.value {
-            ranges.push((data.sourcepos.start.line, data.sourcepos.end.line));
+        let holds_blocks = matches!(
+            &data.value,
+            NodeValue::Document
+                | NodeValue::BlockQuote
+                | NodeValue::MultilineBlockQuote(_)
+                | NodeValue::Alert(_)
+                | NodeValue::List(_)
+                | NodeValue::Item(_)
+                | NodeValue::TaskItem(_)
+                | NodeValue::DescriptionList
+                | NodeValue::DescriptionItem(_)
+                | NodeValue::DescriptionTerm
+                | NodeValue::DescriptionDetails
+                | NodeValue::FootnoteDefinition(_)
+        );
+        if !holds_blocks {
+            let sourcepos = data.sourcepos;
+            let start = if let NodeValue::Paragraph = &data.value {
+                drop(data);
+                Self::paragraph_content_start(
+                    node,
+                    source_lines,
+                    sourcepos.start.line,
+                    sourcepos.end.line,
+                )
+            } else {
+                sourcepos.start.line
+            };
+            ranges.push((start, sourcepos.end.line));
             return;
         }
         drop(data);
 
         for child in node.children() {
-            Self::collect_literal_block_line_ranges(child, ranges);
+            Self::collect_leaf_block_line_ranges(child, source_lines, ranges);
         }
+    }
+
+    /// The first line of a paragraph's own content.
+    ///
+    /// Definitions are consumed from the head of a paragraph, and the node
+    /// keeps the lines they occupied, so those lines have to stay visible to
+    /// the definition scanner while the paragraph's own lines do not.
+    ///
+    /// Two readings bound where the content starts, and a line is left visible
+    /// only where they agree.  The content sits at the end of the span, one
+    /// line per break it contains, which misjudges a paragraph whose inline
+    /// spans lines without a break node, such as a code span or display math
+    /// holding a newline.  A consumed head is also made of definitions, so the
+    /// first line that does not begin one ends it, which instead misjudges a
+    /// paragraph opening with something that merely resembles a definition.
+    /// Neither mistake survives the other.
+    fn paragraph_content_start<'b>(
+        node: &'b AstNode<'b>,
+        source_lines: &[&str],
+        start_line: usize,
+        end_line: usize,
+    ) -> usize {
+        let by_breaks = end_line
+            .saturating_sub(Self::count_line_breaks(node))
+            .max(start_line);
+
+        let mut by_definitions = start_line;
+        while by_definitions < end_line {
+            let Some(line) = source_lines.get(by_definitions - 1) else {
+                break;
+            };
+            let Some(matched) = REFERENCE_DEFINITION.find(line) else {
+                break;
+            };
+            by_definitions += 1;
+            // A label with nothing after its colon takes its destination from
+            // the line below, which the definitions after it sit beneath.  A
+            // title carried onto further lines is not followed this way, and
+            // leaves them counted as content.
+            if line[matched.end()..].trim().is_empty() && by_definitions < end_line {
+                by_definitions += 1;
+            }
+        }
+
+        by_breaks.min(by_definitions)
+    }
+
+    /// Count the line breaks within an inline subtree, which is one fewer than
+    /// the number of source lines its content occupies.
+    fn count_line_breaks<'b>(node: &'b AstNode<'b>) -> usize {
+        let own = match &node.data.borrow().value {
+            NodeValue::SoftBreak | NodeValue::LineBreak => 1,
+            _ => 0,
+        };
+        own + node.children().map(Self::count_line_breaks).sum::<usize>()
     }
 
     /// Collect the normalized labels of the reference definitions the source
     /// carries, each mapped to the lines defining it, in order.
     ///
-    /// Missing a definition would make a later duplicate look like the winning
-    /// one, so the destination is allowed to sit on the following line, as
-    /// CommonMark permits, and a blockquote prefix is allowed to precede the
-    /// label.  A list marker is not: `- [x]: done` is a task list item, and
-    /// mistaking one for a definition is worse than overlooking a definition
-    /// written inside a list.
+    /// The parser resolves references through a map it does not expose, so the
+    /// definitions have to be recognized from the source.  What makes that
+    /// reliable is `leaf_block_ranges`: everything the parser did turn into a
+    /// block is excluded, and a line the parser kept out of every block while
+    /// it looks like a definition is one.  Prose that merely resembles a
+    /// definition, in a paragraph, a code block, raw HTML or a heading, is part
+    /// of its block and never reaches this test.
     ///
-    /// The parser resolves references through a map it does not expose, so this
-    /// recognizes definitions by inspecting the source instead.  It stays on
-    /// the conservative side of the grammar rather than reimplementing it.
     fn collect_reference_definition_lines(
         source_lines: &[&str],
-        literal_block_ranges: &[(usize, usize)],
+        leaf_block_ranges: &[(usize, usize)],
     ) -> std::collections::HashMap<String, Vec<usize>> {
         let mut definitions: std::collections::HashMap<String, Vec<usize>> =
             std::collections::HashMap::new();
-        let ref_def_pattern = Regex::new(r"^[\s>]*\[([^\]]+)\]:(\s*\S.*)?$").unwrap();
 
         for (i, line) in source_lines.iter().enumerate() {
             let line_number = i + 1;
-            if Self::is_line_in_ranges(line_number, literal_block_ranges) {
+            if Self::is_line_in_ranges(line_number, leaf_block_ranges) {
                 continue;
             }
-            if let Some(caps) = ref_def_pattern.captures(line)
+            if let Some(caps) = REFERENCE_DEFINITION.captures(line)
                 && let Some(label) = caps.get(1)
                 // Footnote definitions are not reference definitions.
                 && !label.as_str().starts_with('^')
-                // The destination follows the colon, or, when nothing does, it
-                // is on the next line.  Either way it has to be one.
-                && match caps.get(2) {
-                    Some(same_line) => Self::is_reference_destination(same_line.as_str()),
-                    None => source_lines
-                        .get(i + 1)
-                        .is_some_and(|next| Self::is_reference_destination(next)),
-                }
             {
                 definitions
                     .entry(normalize_reference_key(label.as_str()))
@@ -487,65 +573,6 @@ impl<'a> Serializer<'a> {
         }
 
         definitions
-    }
-
-    /// Whether the text following a reference label's colon can be what a
-    /// definition needs: a destination, optionally followed by a title.
-    ///
-    /// The destination is checked closely, since that is what tells a
-    /// definition apart from ordinary prose.  The title is only checked for its
-    /// opening delimiter, because a title may run on to further lines.
-    fn is_reference_destination(text: &str) -> bool {
-        let trimmed = text.trim();
-        let rest = if let Some(pointy) = trimmed.strip_prefix('<') {
-            // A `<…>` destination may contain spaces, but an unterminated one
-            // is not a destination at all.
-            match pointy.find('>') {
-                Some(end) => pointy[end + 1..].trim(),
-                None => return false,
-            }
-        } else {
-            let (destination, rest) = trimmed
-                .split_once(char::is_whitespace)
-                .unwrap_or((trimmed, ""));
-            // A bare destination has to be non-empty and its parentheses
-            // balanced.  One that opens a bracket is read as the next
-            // definition's label rather than this one's target: `[a]:` followed
-            // by `[b]: …` defines nothing, which is a far more common shape
-            // than a destination that genuinely starts with `[`.
-            if destination.is_empty()
-                || destination.starts_with('[')
-                || !Self::has_balanced_parentheses(destination)
-            {
-                return false;
-            }
-            rest.trim()
-        };
-
-        rest.is_empty() || rest.starts_with(['"', '\'', '('])
-    }
-
-    /// Whether a bare link destination's parentheses pair up, as CommonMark
-    /// requires of one that is not wrapped in `<…>`.
-    fn has_balanced_parentheses(destination: &str) -> bool {
-        let mut depth = 0usize;
-        let mut escaped = false;
-        for character in destination.chars() {
-            if escaped {
-                escaped = false;
-                continue;
-            }
-            match character {
-                '\\' => escaped = true,
-                '(' => depth += 1,
-                ')' => match depth.checked_sub(1) {
-                    Some(remaining) => depth = remaining,
-                    None => return false,
-                },
-                _ => {}
-            }
-        }
-        depth == 0
     }
 
     /// Record the labels that links preserved verbatim depend on, before any

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -71,7 +71,16 @@ impl<'a> Serializer<'a> {
                 }
                 self.reference_definition_lines.insert(label, winner);
             }
-            self.collect_verbatim_reference_claims(node, &copied_lines);
+            self.collect_verbatim_reference_claims(node, &copied_lines, 0);
+
+            // Keep alive the definitions those links depend on.  Each falls due
+            // where the source puts it, so reserving them all here rather than
+            // as each copy is emitted changes nothing about where they land —
+            // except that one due before a copy can no longer miss the flush
+            // that belongs above it.
+            let mut references = Vec::new();
+            self.collect_verbatim_references(node, &copied_lines, &mut references, 0);
+            self.reserve_verbatim_references(references.iter());
         }
 
         // Check for undefined reference links using AST
@@ -125,14 +134,6 @@ impl<'a> Serializer<'a> {
             {
                 match directive {
                     Directive::DisableFile => {
-                        // The rest of the file keeps its source text, so its
-                        // links cannot register the definitions they use.  A
-                        // definition placed before the directive has nowhere
-                        // else to go, so reserve it ahead of the flush below.
-                        for skipped in &children[i + 1..] {
-                            self.reserve_references_of(skipped);
-                        }
-
                         // Flush pending footnotes and references BEFORE the disable-file directive.
                         // Definitions that appear before the directive should stay before it.
                         let directive_line = child.data.borrow().sourcepos.start.line;
@@ -213,25 +214,6 @@ impl<'a> Serializer<'a> {
                             .map(|source| Self::trim_blank_lines(&source))
                             .unwrap_or_default();
 
-                        // Definitions the region's links depend on but that sit
-                        // outside it have to be kept from being dropped.
-                        let mut region_references = Vec::new();
-                        if !region.is_empty() {
-                            for skipped in &children[i + 1..region_last] {
-                                self.collect_verbatim_references(skipped, &mut region_references);
-                            }
-                        }
-                        // A label the copy redefines has to be reserved before
-                        // the flush below, so that its winning definition still
-                        // comes first in the output; the copy would otherwise
-                        // shadow it and retarget the links.
-                        let (shadowed, rest): (Vec<_>, Vec<_>) =
-                            region_references.iter().partition(|reference| {
-                                self.shadowed_reference_labels
-                                    .contains(&normalize_reference_key(&reference.label))
-                            });
-                        self.reserve_verbatim_references(shadowed.into_iter());
-
                         // Flush pending footnotes and references BEFORE the disable directive.
                         // Definitions that appear before the directive should stay before it.
                         let directive_line = child.data.borrow().sourcepos.start.line;
@@ -252,10 +234,6 @@ impl<'a> Serializer<'a> {
                             // back to emitting its blocks one by one.
                             self.skip_mode = FormatSkipMode::Disabled;
                         } else {
-                            // The rest are reserved after the flush, so they are
-                            // emitted where definitions normally go rather than
-                            // above the directive.
-                            self.reserve_verbatim_references(rest.into_iter());
                             self.output.push('\n');
                             self.output.push_str(&region);
                             self.output.push('\n');
@@ -355,10 +333,6 @@ impl<'a> Serializer<'a> {
                     self.serialize_node(child);
                     continue;
                 }
-
-                // The block keeps its source text, so its links never register
-                // the definitions they use; reserve them here instead.
-                self.reserve_references_of(child);
 
                 // Output the original source
                 if let Some(source) = self.extract_source(child) {
@@ -549,16 +523,140 @@ impl<'a> Serializer<'a> {
                 break;
             };
             by_definitions += 1;
-            // A label with nothing after its colon takes its destination from
-            // the line below, which the definitions after it sit beneath.  A
-            // title carried onto further lines is not followed this way, and
-            // leaves them counted as content.
-            if line[matched.end()..].trim().is_empty() && by_definitions < end_line {
+            // A definition may be written over several lines: its destination
+            // on the line below the label, and a title after the destination or
+            // on a line of its own below it, running on further still.  The
+            // definitions after it sit beneath all of that, so the head reaches
+            // over it to find them.
+            let mut rest = &line[matched.end()..];
+            if rest.trim().is_empty() && by_definitions < end_line {
+                rest = source_lines.get(by_definitions - 1).copied().unwrap_or("");
                 by_definitions += 1;
+            }
+            let Some(title) = Self::title_after_destination(rest) else {
+                // The destination is malformed, so nothing here is a definition
+                // to reach over.
+                break;
+            };
+            let mut closing = Self::unclosed_delimiter_in(title);
+            if title.trim().is_empty()
+                && by_definitions < end_line
+                && let Some(below) = source_lines.get(by_definitions - 1)
+                && Self::starts_title(below)
+            {
+                by_definitions += 1;
+                closing = Self::unclosed_delimiter_in(below);
+            }
+            if let Some(closing) = closing {
+                // The delimiter that opened the title is what closes it, however
+                // many lines later, and one the source escapes closes nothing.
+                while by_definitions < end_line {
+                    let line = source_lines.get(by_definitions - 1).copied().unwrap_or("");
+                    by_definitions += 1;
+                    if Self::contains_unescaped(line, closing) {
+                        break;
+                    }
+                }
             }
         }
 
         by_breaks.min(by_definitions)
+    }
+
+    /// How far a block's reported start sits above its own content, which is
+    /// how far the lines reported for anything inside it sit above their real
+    /// ones.
+    ///
+    /// Only the blocks that swallow a consumed head have such a gap; `None`
+    /// says the node is not one of them and whatever gap encloses it still
+    /// applies.
+    fn consumed_head_offset<'b>(&self, node: &'b AstNode<'b>) -> Option<usize> {
+        let (underline_lines, sourcepos) = {
+            let data = node.data.borrow();
+            let underline_lines = match &data.value {
+                NodeValue::Paragraph => 0,
+                NodeValue::Heading(heading) if heading.setext => 1,
+                _ => return None,
+            };
+            (underline_lines, data.sourcepos)
+        };
+        let content_start = Self::leaf_content_start(
+            node,
+            &self.source_lines,
+            sourcepos.start.line,
+            sourcepos.end.line,
+            underline_lines,
+        );
+        Some(content_start.saturating_sub(sourcepos.start.line))
+    }
+
+    /// Whether a line holds `delimiter` with no backslash escaping it.
+    fn contains_unescaped(text: &str, delimiter: char) -> bool {
+        Self::find_unescaped(text, delimiter).is_some()
+    }
+
+    /// The byte offset of `delimiter` in a line, skipping any the source
+    /// escapes with a backslash.
+    fn find_unescaped(text: &str, delimiter: char) -> Option<usize> {
+        let mut escaped = false;
+        for (offset, character) in text.char_indices() {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            match character {
+                '\\' => escaped = true,
+                _ if character == delimiter => return Some(offset),
+                _ => {}
+            }
+        }
+        None
+    }
+
+    /// The part of a definition's text that follows its destination, which is
+    /// where a title may be written.  `None` where the destination is malformed
+    /// and the text is therefore no definition's.
+    ///
+    /// The destination comes first and may hold a quote or a parenthesis of its
+    /// own, so only what follows it can open a title.
+    fn title_after_destination(text: &str) -> Option<&str> {
+        let trimmed = text.trim_start();
+        match trimmed.strip_prefix('<') {
+            // An unterminated `<…>` is no destination at all.
+            Some(pointy) => Some(&pointy[Self::find_unescaped(pointy, '>')? + 1..]),
+            None => Some(match trimmed.split_once(char::is_whitespace) {
+                Some((_, title)) => title,
+                None => "",
+            }),
+        }
+    }
+
+    /// Whether a line of its own begins a title, as one below a definition's
+    /// destination may.
+    fn starts_title(line: &str) -> bool {
+        line.trim_start().starts_with(['"', '\'', '('])
+    }
+
+    /// What a stretch of title text leaves for a later line to close.
+    fn unclosed_delimiter_in(title: &str) -> Option<char> {
+        let mut escaped = false;
+        let mut quote = None;
+        let mut depth = 0usize;
+        for character in title.chars() {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            match character {
+                '\\' => escaped = true,
+                '"' | '\'' if quote == Some(character) => quote = None,
+                '"' | '\'' if quote.is_none() && depth == 0 => quote = Some(character),
+                '(' if quote.is_none() => depth += 1,
+                ')' if quote.is_none() => depth = depth.saturating_sub(1),
+                _ => {}
+            }
+        }
+        quote.or(if depth > 0 { Some(')') } else { None })
     }
 
     /// Count the line breaks within an inline subtree, which is one fewer than
@@ -724,9 +822,11 @@ impl<'a> Serializer<'a> {
         &mut self,
         node: &'b AstNode<'b>,
         copied_lines: &[bool],
+        line_offset: usize,
     ) {
+        let child_offset = self.consumed_head_offset(node).unwrap_or(line_offset);
         for child in node.children() {
-            self.collect_verbatim_reference_claims(child, copied_lines);
+            self.collect_verbatim_reference_claims(child, copied_lines, child_offset);
         }
 
         let (target, line) = {
@@ -737,12 +837,12 @@ impl<'a> Serializer<'a> {
                 }
                 _ => None,
             };
-            (target, data.sourcepos.start.line)
+            (target, data.sourcepos.start.line + line_offset)
         };
 
         if let Some((url, title)) = target
             && Self::is_line_marked(line, copied_lines)
-            && let Some(label) = self.verbatim_reference_label(node)
+            && let Some(label) = self.verbatim_reference_label(node, line_offset)
         {
             self.verbatim_reference_claims
                 .entry(normalize_reference_key(&label))
@@ -753,8 +853,12 @@ impl<'a> Serializer<'a> {
     /// The label a reference-style link or image is written with in the source,
     /// with the collapsed-reference marker stripped.  `None` for links that are
     /// not reference style, and for the empty label, which cannot be defined.
-    fn verbatim_reference_label<'b>(&self, node: &'b AstNode<'b>) -> Option<String> {
-        let (_, label) = self.get_reference_style_info(node)?;
+    fn verbatim_reference_label<'b>(
+        &self,
+        node: &'b AstNode<'b>,
+        line_offset: usize,
+    ) -> Option<String> {
+        let (_, label) = self.get_reference_style_info_shifted(node, line_offset)?;
         let label = label.strip_prefix('\x01').unwrap_or(&label);
         (!label.is_empty()).then(|| label.to_string())
     }
@@ -768,12 +872,15 @@ impl<'a> Serializer<'a> {
     fn collect_verbatim_references<'b>(
         &self,
         node: &'b AstNode<'b>,
+        copied_lines: &[bool],
         collected: &mut Vec<VerbatimReference>,
+        line_offset: usize,
     ) {
+        let child_offset = self.consumed_head_offset(node).unwrap_or(line_offset);
         // Children first, so that a badge's image comes before the link
         // wrapping it, the order the formatted path would register them in.
         for child in node.children() {
-            self.collect_verbatim_references(child, collected);
+            self.collect_verbatim_references(child, copied_lines, collected, child_offset);
         }
 
         let (target, line) = {
@@ -784,11 +891,12 @@ impl<'a> Serializer<'a> {
                 }
                 _ => None,
             };
-            (target, data.sourcepos.start.line)
+            (target, data.sourcepos.start.line + line_offset)
         };
 
         if let Some((url, title)) = target
-            && let Some(label) = self.verbatim_reference_label(node)
+            && Self::is_line_marked(line, copied_lines)
+            && let Some(label) = self.verbatim_reference_label(node, line_offset)
         {
             collected.push(VerbatimReference {
                 label,
@@ -822,13 +930,6 @@ impl<'a> Serializer<'a> {
                 );
             }
         }
-    }
-
-    /// Collect and reserve in one step, for a single block emitted verbatim.
-    fn reserve_references_of<'b>(&mut self, node: &'b AstNode<'b>) {
-        let mut references = Vec::new();
-        self.collect_verbatim_references(node, &mut references);
-        self.reserve_verbatim_references(references.iter());
     }
 
     /// Drop the leading and trailing blank lines of a verbatim source chunk,
@@ -1594,5 +1695,39 @@ impl<'a> Serializer<'a> {
 
         self.output.push_str(style);
         self.output.push('\n');
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Serializer;
+
+    /// The text a reference definition carries after its label's colon, and
+    /// what of a title it leaves open for the lines below to close.
+    #[test]
+    fn test_unclosed_title_delimiter() {
+        let open = |text: &str| {
+            Serializer::title_after_destination(text).and_then(Serializer::unclosed_delimiter_in)
+        };
+
+        // Nothing but a destination opens nothing.
+        assert_eq!(open(" https://example.com/a"), None);
+        assert_eq!(open(" <https://example.com/a>"), None);
+        // A destination may hold what a title would open with.
+        assert_eq!(open(" <https://example.com/foo\"bar>"), None);
+        assert_eq!(open(" <https://example.com/foo(bar>"), None);
+        assert_eq!(open(" <https://example.com/foo'bar>"), None);
+        // A title closed on the same line needs no continuation.
+        assert_eq!(open(" https://example.com/a \"A title\""), None);
+        assert_eq!(open(" https://example.com/a (A title)"), None);
+        // One left open names the delimiter that will close it.
+        assert_eq!(open(" https://example.com/a \"A title"), Some('"'));
+        assert_eq!(open(" <https://example.com/a> \"A title"), Some('"'));
+        assert_eq!(open(" https://example.com/a 'A title"), Some('\''));
+        assert_eq!(open(" https://example.com/a (A title"), Some(')'));
+        // An escaped delimiter closes nothing.
+        assert_eq!(open(" https://example.com/a \"A \\\"title"), Some('"'));
+        // An unterminated `<…>` is no destination at all.
+        assert_eq!(open(" <https://example.com/a \"A title"), None);
     }
 }

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -603,25 +603,7 @@ impl<'a> Serializer<'a> {
 
     /// Whether a line holds `delimiter` with no backslash escaping it.
     fn contains_unescaped(text: &str, delimiter: char) -> bool {
-        Self::find_unescaped(text, delimiter).is_some()
-    }
-
-    /// The byte offset of `delimiter` in a line, skipping any the source
-    /// escapes with a backslash.
-    fn find_unescaped(text: &str, delimiter: char) -> Option<usize> {
-        let mut escaped = false;
-        for (offset, character) in text.char_indices() {
-            if escaped {
-                escaped = false;
-                continue;
-            }
-            match character {
-                '\\' => escaped = true,
-                _ if character == delimiter => return Some(offset),
-                _ => {}
-            }
-        }
-        None
+        super::find_unescaped(text, delimiter).is_some()
     }
 
     /// The part of a definition's text that follows its destination, which is
@@ -634,7 +616,7 @@ impl<'a> Serializer<'a> {
         let trimmed = text.trim_start();
         match trimmed.strip_prefix('<') {
             // An unterminated `<…>` is no destination at all.
-            Some(pointy) => Some(&pointy[Self::find_unescaped(pointy, '>')? + 1..]),
+            Some(pointy) => Some(&pointy[super::find_unescaped(pointy, '>')? + 1..]),
             None => Some(match trimmed.split_once(char::is_whitespace) {
                 Some((_, title)) => title,
                 None => "",
@@ -669,7 +651,7 @@ impl<'a> Serializer<'a> {
         // however many lines below that is.
         let mut label = String::new();
         let after_label = loop {
-            match Self::find_unescaped(rest, ']') {
+            match super::find_unescaped(rest, ']') {
                 Some(end) => {
                     label.push_str(&rest[..end]);
                     break &rest[end + 1..];

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -6,15 +6,53 @@ use unicode_width::UnicodeWidthStr;
 
 use super::Serializer;
 use super::escape;
-use super::state::{Directive, FormatSkipMode};
+use super::state::{Directive, FormatSkipMode, ReferenceLink, normalize_reference_key};
 use super::wrap;
+
+/// A reference definition that a link preserved verbatim depends on.
+struct VerbatimReference {
+    label: String,
+    url: String,
+    title: String,
+    /// Line of the link that needs it, for reporting.
+    line: usize,
+}
 
 impl<'a> Serializer<'a> {
     pub(super) fn serialize_document<'b>(&mut self, node: &'b AstNode<'b>) {
         let children: Vec<_> = node.children().collect();
 
+        // Source ranges that are copied verbatim rather than rebuilt from the
+        // AST.  Whatever they contain — reference definitions, footnote
+        // definitions, comments — travels with the copy and must not be
+        // emitted a second time from elsewhere.
+        let verbatim_ranges = self.collect_verbatim_line_ranges(&children);
+        // Every range whose content keeps its source text, which is the wider
+        // set: it also covers the blocks the skip modes emit one by one.
+        let disabled_ranges = Self::collect_disabled_line_ranges(node);
+
+        let mut literal_block_ranges = Vec::new();
+        Self::collect_literal_block_line_ranges(node, &mut literal_block_ranges);
+        for (label, lines) in
+            Self::collect_reference_definition_lines(&self.source_lines, &literal_block_ranges)
+        {
+            // Only the first definition of a label counts, the way CommonMark
+            // resolves it.  When it is the one the copy carries, the copy also
+            // defines it; when a *later* one is, the copy merely repeats a
+            // definition that has no effect where it stands but would take
+            // effect if the winning one were emitted after it.
+            let mut lines = lines.into_iter();
+            let winner = lines.next().unwrap_or_default();
+            if Self::is_line_in_ranges(winner, &verbatim_ranges) {
+                self.verbatim_reference_labels.insert(label);
+            } else if lines.any(|line| Self::is_line_in_ranges(line, &verbatim_ranges)) {
+                self.shadowed_reference_labels.insert(label);
+            }
+        }
+        self.collect_verbatim_reference_claims(node, &disabled_ranges);
+
         // Check for undefined reference links using AST
-        self.check_undefined_references_ast(node);
+        self.check_undefined_references_ast(node, &disabled_ranges);
 
         // First pass: collect all footnote reference lines
         // This is needed because FootnoteDefinition nodes come at the end of the AST,
@@ -25,15 +63,28 @@ impl<'a> Serializer<'a> {
         // This ensures pending_footnotes is populated before we flush at section boundaries
         for child in &children {
             if let NodeValue::FootnoteDefinition(_) = &child.data.borrow().value {
+                // A footnote definition inside a verbatim range is copied with
+                // the range, so collecting it here would emit it twice.
+                let line = child.data.borrow().sourcepos.start.line;
+                if Self::is_line_in_ranges(line, &verbatim_ranges) {
+                    continue;
+                }
                 self.serialize_node(child);
             }
         }
 
         // Identify trailing HTML blocks (non-directive comments at the end of document)
         // These should be output after reference definitions to maintain their position
-        let trailing_html_start = self.find_trailing_html_blocks(&children);
+        let trailing_html_start = self.find_trailing_html_blocks(&children, &verbatim_ranges);
+
+        // Index before which children have already been emitted as part of a
+        // verbatim region.
+        let mut skip_until = 0usize;
 
         for (i, child) in children.iter().enumerate() {
+            if i < skip_until {
+                continue;
+            }
             // Skip trailing HTML blocks for now - they'll be output after references
             if i >= trailing_html_start
                 && let NodeValue::HtmlBlock(_) = &child.data.borrow().value
@@ -50,6 +101,14 @@ impl<'a> Serializer<'a> {
             {
                 match directive {
                     Directive::DisableFile => {
+                        // The rest of the file keeps its source text, so its
+                        // links cannot register the definitions they use.  A
+                        // definition placed before the directive has nowhere
+                        // else to go, so reserve it ahead of the flush below.
+                        for skipped in &children[i + 1..] {
+                            self.reserve_references_of(skipped);
+                        }
+
                         // Flush pending footnotes and references BEFORE the disable-file directive.
                         // Definitions that appear before the directive should stay before it.
                         let directive_line = child.data.borrow().sourcepos.start.line;
@@ -57,7 +116,11 @@ impl<'a> Serializer<'a> {
                         self.flush_references();
                         self.flush_footnote_references_before(Some(directive_line));
 
-                        // Output the directive comment, then output remaining content as-is
+                        // Output the directive comment, then output remaining content as-is.
+                        // A definition flushed just above would otherwise run
+                        // straight into the comment, and it has no node of its
+                        // own for the child index to account for.
+                        self.ensure_blank_line();
                         self.output.push_str(html_block.literal.trim_end());
                         // Get the line after the directive block ends
                         let directive_end_line = child.data.borrow().sourcepos.end.line;
@@ -79,10 +142,10 @@ impl<'a> Serializer<'a> {
                         self.flush_footnote_references_before(Some(directive_line));
 
                         self.skip_mode = FormatSkipMode::NextBlock;
-                        // Output the directive comment
-                        if i > 0 {
-                            self.output.push('\n');
-                        }
+                        // Output the directive comment.  A definition flushed
+                        // just above has no node of its own for the child index
+                        // to account for, so the separator goes by the output.
+                        self.ensure_blank_line();
                         self.output.push_str(&html_block.literal);
                         continue;
                     }
@@ -95,14 +158,56 @@ impl<'a> Serializer<'a> {
                         self.flush_footnote_references_before(Some(directive_line));
 
                         self.skip_mode = FormatSkipMode::UntilSection;
-                        // Output the directive comment
-                        if i > 0 {
-                            self.output.push('\n');
-                        }
+                        // Output the directive comment.  A definition flushed
+                        // just above has no node of its own for the child index
+                        // to account for, so the separator goes by the output.
+                        self.ensure_blank_line();
                         self.output.push_str(&html_block.literal);
                         continue;
                     }
                     Directive::Disable => {
+                        // The region is copied from the source instead of being
+                        // rebuilt block by block: a reference definition is
+                        // consumed by the parser and has no node of its own, so
+                        // a node-by-node copy would leave the region's links
+                        // pointing at nothing.
+                        let enable_index = Self::find_enable_directive(&children, i);
+                        let region_last = enable_index.unwrap_or(children.len());
+                        let region_start = child.data.borrow().sourcepos.end.line + 1;
+                        let region_end = match enable_index {
+                            Some(j) => children[j]
+                                .data
+                                .borrow()
+                                .sourcepos
+                                .start
+                                .line
+                                .saturating_sub(1),
+                            None => self.source_lines.len(),
+                        };
+                        let region = self
+                            .extract_source_lines(region_start, region_end)
+                            .map(|source| Self::trim_blank_lines(&source))
+                            .unwrap_or_default();
+
+                        // Definitions the region's links depend on but that sit
+                        // outside it have to be kept from being dropped.
+                        let mut region_references = Vec::new();
+                        if !region.is_empty() {
+                            for skipped in &children[i + 1..region_last] {
+                                self.collect_verbatim_references(skipped, &mut region_references);
+                            }
+                        }
+                        // A label the copy redefines has to be reserved before
+                        // the flush below, so that its winning definition still
+                        // comes first in the output; the copy would otherwise
+                        // shadow it and retarget the links.
+                        let (shadowed, rest): (Vec<_>, Vec<_>) =
+                            region_references.iter().partition(|reference| {
+                                self.shadowed_reference_labels
+                                    .contains(&normalize_reference_key(&reference.label))
+                            });
+                        self.reserve_verbatim_references(shadowed.into_iter());
+
                         // Flush pending footnotes and references BEFORE the disable directive.
                         // Definitions that appear before the directive should stay before it.
                         let directive_line = child.data.borrow().sourcepos.start.line;
@@ -110,40 +215,56 @@ impl<'a> Serializer<'a> {
                         self.flush_references();
                         self.flush_footnote_references_before(Some(directive_line));
 
-                        self.skip_mode = FormatSkipMode::Disabled;
-                        // Output the directive comment
-                        if i > 0 {
+                        // Output the directive comment.  A definition flushed
+                        // just above has no node of its own for the child index
+                        // to account for, so the separator goes by the output.
+                        self.ensure_blank_line();
+                        self.output.push_str(html_block.literal.trim_end());
+                        self.output.push('\n');
+
+                        if region.is_empty() {
+                            // Nothing to copy, either because the region is
+                            // empty or because the source is unavailable; fall
+                            // back to emitting its blocks one by one.
+                            self.skip_mode = FormatSkipMode::Disabled;
+                        } else {
+                            // The rest are reserved after the flush, so they are
+                            // emitted where definitions normally go rather than
+                            // above the directive.
+                            self.reserve_verbatim_references(rest.into_iter());
                             self.output.push('\n');
+                            self.output.push_str(&region);
+                            self.output.push('\n');
+                            skip_until = region_last;
                         }
-                        self.output.push_str(&html_block.literal);
                         continue;
                     }
                     Directive::Enable => {
                         self.skip_mode = FormatSkipMode::None;
-                        // Output the directive comment
-                        if i > 0 {
-                            self.output.push('\n');
-                        }
+                        // Output the directive comment.  A definition flushed
+                        // just above has no node of its own for the child index
+                        // to account for, so the separator goes by the output.
+                        self.ensure_blank_line();
                         self.output.push_str(&html_block.literal);
                         continue;
                     }
                     Directive::ProperNouns(nouns) => {
                         // Add to directive proper nouns list
                         self.directive_proper_nouns.extend(nouns);
-                        // Output the directive comment
-                        if i > 0 {
-                            self.output.push('\n');
-                        }
+                        // Output the directive comment.  A definition flushed
+                        // just above has no node of its own for the child index
+                        // to account for, so the separator goes by the output.
+                        self.ensure_blank_line();
                         self.output.push_str(&html_block.literal);
                         continue;
                     }
                     Directive::CommonNouns(nouns) => {
                         // Add to directive common nouns list
                         self.directive_common_nouns.extend(nouns);
-                        // Output the directive comment
-                        if i > 0 {
-                            self.output.push('\n');
-                        }
+                        // Output the directive comment.  A definition flushed
+                        // just above has no node of its own for the child index
+                        // to account for, so the separator goes by the output.
+                        self.ensure_blank_line();
                         self.output.push_str(&html_block.literal);
                         continue;
                     }
@@ -211,6 +332,10 @@ impl<'a> Serializer<'a> {
                     continue;
                 }
 
+                // The block keeps its source text, so its links never register
+                // the definitions they use; reserve them here instead.
+                self.reserve_references_of(child);
+
                 // Output the original source
                 if let Some(source) = self.extract_source(child) {
                     self.output.push_str(&source);
@@ -233,9 +358,335 @@ impl<'a> Serializer<'a> {
         self.output_trailing_html_blocks(&children, trailing_html_start);
     }
 
+    /// Find the index of the `hongdown-enable` directive that closes the
+    /// `hongdown-disable` directive at `from`, if the document has one.
+    fn find_enable_directive<'b>(children: &[&'b AstNode<'b>], from: usize) -> Option<usize> {
+        children
+            .iter()
+            .enumerate()
+            .skip(from + 1)
+            .find(|(_, child)| {
+                matches!(
+                    &child.data.borrow().value,
+                    NodeValue::HtmlBlock(html_block)
+                        if Directive::parse(&html_block.literal) == Some(Directive::Enable)
+                )
+            })
+            .map(|(i, _)| i)
+    }
+
+    /// Collect the source line ranges that are copied verbatim instead of being
+    /// rebuilt from the AST: every `hongdown-disable` region and the tail that
+    /// follows a `hongdown-disable-file` directive.
+    fn collect_verbatim_line_ranges<'b>(
+        &self,
+        children: &[&'b AstNode<'b>],
+    ) -> Vec<(usize, usize)> {
+        let mut ranges = Vec::new();
+        let last_line = self.source_lines.len();
+        let mut i = 0;
+
+        while i < children.len() {
+            let directive = match &children[i].data.borrow().value {
+                NodeValue::HtmlBlock(html_block) => Directive::parse(&html_block.literal),
+                _ => None,
+            };
+            let start_line = children[i].data.borrow().sourcepos.end.line + 1;
+            match directive {
+                Some(Directive::DisableFile) => {
+                    ranges.push((start_line, last_line));
+                    break;
+                }
+                Some(Directive::Disable) => {
+                    let enable_index = Self::find_enable_directive(children, i);
+                    let end_line = match enable_index {
+                        Some(j) => children[j]
+                            .data
+                            .borrow()
+                            .sourcepos
+                            .start
+                            .line
+                            .saturating_sub(1),
+                        None => last_line,
+                    };
+                    ranges.push((start_line, end_line));
+                    // Nested directives inside the region are part of the copy.
+                    i = enable_index.unwrap_or(children.len());
+                }
+                _ => {}
+            }
+            i += 1;
+        }
+
+        ranges
+    }
+
+    /// Collect the source line ranges covered by code blocks and raw HTML
+    /// blocks, whose contents are not Markdown and so may not be mistaken for
+    /// reference definitions.
+    fn collect_literal_block_line_ranges<'b>(
+        node: &'b AstNode<'b>,
+        ranges: &mut Vec<(usize, usize)>,
+    ) {
+        let data = node.data.borrow();
+        if let NodeValue::CodeBlock(_) | NodeValue::HtmlBlock(_) = &data.value {
+            ranges.push((data.sourcepos.start.line, data.sourcepos.end.line));
+            return;
+        }
+        drop(data);
+
+        for child in node.children() {
+            Self::collect_literal_block_line_ranges(child, ranges);
+        }
+    }
+
+    /// Collect the normalized labels of the reference definitions the source
+    /// carries, each mapped to the lines defining it, in order.
+    ///
+    /// Missing a definition would make a later duplicate look like the winning
+    /// one, so the destination is allowed to sit on the following line, as
+    /// CommonMark permits, and a blockquote prefix is allowed to precede the
+    /// label.  A list marker is not: `- [x]: done` is a task list item, and
+    /// mistaking one for a definition is worse than overlooking a definition
+    /// written inside a list.
+    ///
+    /// The parser resolves references through a map it does not expose, so this
+    /// recognizes definitions by inspecting the source instead.  It stays on
+    /// the conservative side of the grammar rather than reimplementing it.
+    fn collect_reference_definition_lines(
+        source_lines: &[&str],
+        literal_block_ranges: &[(usize, usize)],
+    ) -> std::collections::HashMap<String, Vec<usize>> {
+        let mut definitions: std::collections::HashMap<String, Vec<usize>> =
+            std::collections::HashMap::new();
+        let ref_def_pattern = Regex::new(r"^[\s>]*\[([^\]]+)\]:(\s*\S.*)?$").unwrap();
+
+        for (i, line) in source_lines.iter().enumerate() {
+            let line_number = i + 1;
+            if Self::is_line_in_ranges(line_number, literal_block_ranges) {
+                continue;
+            }
+            if let Some(caps) = ref_def_pattern.captures(line)
+                && let Some(label) = caps.get(1)
+                // Footnote definitions are not reference definitions.
+                && !label.as_str().starts_with('^')
+                // The destination follows the colon, or, when nothing does, it
+                // is on the next line.  Either way it has to be one.
+                && match caps.get(2) {
+                    Some(same_line) => Self::is_reference_destination(same_line.as_str()),
+                    None => source_lines
+                        .get(i + 1)
+                        .is_some_and(|next| Self::is_reference_destination(next)),
+                }
+            {
+                definitions
+                    .entry(normalize_reference_key(label.as_str()))
+                    .or_default()
+                    .push(line_number);
+            }
+        }
+
+        definitions
+    }
+
+    /// Whether the text following a reference label's colon can be what a
+    /// definition needs: a destination, optionally followed by a title.
+    ///
+    /// The destination is checked closely, since that is what tells a
+    /// definition apart from ordinary prose.  The title is only checked for its
+    /// opening delimiter, because a title may run on to further lines.
+    fn is_reference_destination(text: &str) -> bool {
+        let trimmed = text.trim();
+        let rest = if let Some(pointy) = trimmed.strip_prefix('<') {
+            // A `<…>` destination may contain spaces, but an unterminated one
+            // is not a destination at all.
+            match pointy.find('>') {
+                Some(end) => pointy[end + 1..].trim(),
+                None => return false,
+            }
+        } else {
+            let (destination, rest) = trimmed
+                .split_once(char::is_whitespace)
+                .unwrap_or((trimmed, ""));
+            // A bare destination has to be non-empty and its parentheses
+            // balanced.  One that opens a bracket is read as the next
+            // definition's label rather than this one's target: `[a]:` followed
+            // by `[b]: …` defines nothing, which is a far more common shape
+            // than a destination that genuinely starts with `[`.
+            if destination.is_empty()
+                || destination.starts_with('[')
+                || !Self::has_balanced_parentheses(destination)
+            {
+                return false;
+            }
+            rest.trim()
+        };
+
+        rest.is_empty() || rest.starts_with(['"', '\'', '('])
+    }
+
+    /// Whether a bare link destination's parentheses pair up, as CommonMark
+    /// requires of one that is not wrapped in `<…>`.
+    fn has_balanced_parentheses(destination: &str) -> bool {
+        let mut depth = 0usize;
+        let mut escaped = false;
+        for character in destination.chars() {
+            if escaped {
+                escaped = false;
+                continue;
+            }
+            match character {
+                '\\' => escaped = true,
+                '(' => depth += 1,
+                ')' => match depth.checked_sub(1) {
+                    Some(remaining) => depth = remaining,
+                    None => return false,
+                },
+                _ => {}
+            }
+        }
+        depth == 0
+    }
+
+    /// Record the labels that links preserved verbatim depend on, before any
+    /// link is serialized.
+    ///
+    /// A link that is copied from the source keeps the label the source gave
+    /// it, whereas a formatted link can be given a derived label such as
+    /// `[guide][guide 2]`.  Claiming the labels up front is therefore what lets
+    /// the two coexist: the formatted link is the one that yields.
+    fn collect_verbatim_reference_claims<'b>(
+        &mut self,
+        node: &'b AstNode<'b>,
+        disabled_ranges: &[(usize, usize)],
+    ) {
+        for child in node.children() {
+            self.collect_verbatim_reference_claims(child, disabled_ranges);
+        }
+
+        let (target, line) = {
+            let data = node.data.borrow();
+            let target = match &data.value {
+                NodeValue::Link(link) | NodeValue::Image(link) => {
+                    Some((link.url.clone(), link.title.clone()))
+                }
+                _ => None,
+            };
+            (target, data.sourcepos.start.line)
+        };
+
+        if let Some((url, title)) = target
+            && Self::is_line_in_ranges(line, disabled_ranges)
+            && let Some(label) = self.verbatim_reference_label(node)
+        {
+            self.verbatim_reference_claims
+                .entry(normalize_reference_key(&label))
+                .or_insert(ReferenceLink { label, url, title });
+        }
+    }
+
+    /// The label a reference-style link or image is written with in the source,
+    /// with the collapsed-reference marker stripped.  `None` for links that are
+    /// not reference style, and for the empty label, which cannot be defined.
+    fn verbatim_reference_label<'b>(&self, node: &'b AstNode<'b>) -> Option<String> {
+        let (_, label) = self.get_reference_style_info(node)?;
+        let label = label.strip_prefix('\x01').unwrap_or(&label);
+        (!label.is_empty()).then(|| label.to_string())
+    }
+
+    /// Collect the reference definitions a verbatim block's links depend on.
+    ///
+    /// Such a link is copied from the source and so never registers the
+    /// definition it uses; without [`Self::reserve_verbatim_references`] the
+    /// definition would be dropped as unused, leaving the copy pointing at
+    /// nothing.
+    fn collect_verbatim_references<'b>(
+        &self,
+        node: &'b AstNode<'b>,
+        collected: &mut Vec<VerbatimReference>,
+    ) {
+        // Children first, so that a badge's image comes before the link
+        // wrapping it, the order the formatted path would register them in.
+        for child in node.children() {
+            self.collect_verbatim_references(child, collected);
+        }
+
+        let (target, line) = {
+            let data = node.data.borrow();
+            let target = match &data.value {
+                NodeValue::Link(link) | NodeValue::Image(link) => {
+                    Some((link.url.clone(), link.title.clone()))
+                }
+                _ => None,
+            };
+            (target, data.sourcepos.start.line)
+        };
+
+        if let Some((url, title)) = target
+            && let Some(label) = self.verbatim_reference_label(node)
+        {
+            collected.push(VerbatimReference {
+                label,
+                url,
+                title,
+                line,
+            });
+        }
+    }
+
+    /// Keep the given definitions from being dropped as unused, reporting the
+    /// ones whose label is already spoken for by a different destination.
+    fn reserve_verbatim_references<'r>(
+        &mut self,
+        references: impl Iterator<Item = &'r VerbatimReference>,
+    ) {
+        for reference in references {
+            // A definition inside a verbatim range travels with its own copy.
+            let key = normalize_reference_key(&reference.label);
+            if self.verbatim_reference_labels.contains(&key) {
+                continue;
+            }
+            if !self.reserve_reference(&reference.label, &reference.url, &reference.title) {
+                self.add_warning(
+                    reference.line,
+                    format!(
+                        "reference definition [{}] cannot be kept: the label is \
+                         already used for a different destination",
+                        reference.label
+                    ),
+                );
+            }
+        }
+    }
+
+    /// Collect and reserve in one step, for a single block emitted verbatim.
+    fn reserve_references_of<'b>(&mut self, node: &'b AstNode<'b>) {
+        let mut references = Vec::new();
+        self.collect_verbatim_references(node, &mut references);
+        self.reserve_verbatim_references(references.iter());
+    }
+
+    /// Drop the leading and trailing blank lines of a verbatim source chunk,
+    /// leaving the indentation of the remaining lines untouched.
+    fn trim_blank_lines(source: &str) -> String {
+        let lines: Vec<&str> = source.lines().collect();
+        let Some(start) = lines.iter().position(|line| !line.trim().is_empty()) else {
+            return String::new();
+        };
+        let end = lines
+            .iter()
+            .rposition(|line| !line.trim().is_empty())
+            .unwrap_or(start);
+        lines[start..=end].join("\n")
+    }
+
     /// Find the index where trailing HTML blocks start.
     /// Returns `children.len()` if there are no trailing HTML blocks.
-    fn find_trailing_html_blocks<'b>(&self, children: &[&'b AstNode<'b>]) -> usize {
+    fn find_trailing_html_blocks<'b>(
+        &self,
+        children: &[&'b AstNode<'b>],
+        verbatim_ranges: &[(usize, usize)],
+    ) -> usize {
         let mut trailing_start = children.len();
 
         // Walk backwards from the end, looking for consecutive HTML blocks
@@ -245,6 +696,12 @@ impl<'a> Serializer<'a> {
                 NodeValue::HtmlBlock(html_block) => {
                     // Skip formatting directives - they should stay where they are
                     if Directive::parse(&html_block.literal).is_some() {
+                        break;
+                    }
+                    // A block inside a verbatim range is emitted with that
+                    // range; moving it here would emit it twice.
+                    let start_line = child.data.borrow().sourcepos.start.line;
+                    if Self::is_line_in_ranges(start_line, verbatim_ranges) {
                         break;
                     }
                     // This is a regular HTML block (e.g., comment) - mark as trailing
@@ -656,7 +1113,11 @@ impl<'a> Serializer<'a> {
     ///
     /// We also check the original source to ensure the bracket wasn't
     /// intentionally escaped (e.g., `\[label]`).
-    fn check_undefined_references_ast<'b>(&mut self, node: &'b AstNode<'b>) {
+    fn check_undefined_references_ast<'b>(
+        &mut self,
+        node: &'b AstNode<'b>,
+        disabled_ranges: &[(usize, usize)],
+    ) {
         if self.source_lines.is_empty() {
             return;
         }
@@ -668,9 +1129,6 @@ impl<'a> Serializer<'a> {
         // (e.g., when they follow abbreviation definitions without a blank line)
         let source_ref_defs = Self::collect_source_reference_definitions(&self.source_lines);
 
-        // Collect disabled line ranges based on formatting directives
-        let disabled_ranges = Self::collect_disabled_line_ranges(node);
-
         // Collect warnings first to avoid borrow issues
         let warnings = Self::find_undefined_references_in_ast(
             node,
@@ -681,7 +1139,7 @@ impl<'a> Serializer<'a> {
 
         // Filter out warnings that fall within disabled regions
         for (line, msg) in warnings {
-            if !Self::is_line_in_disabled_ranges(line, &disabled_ranges) {
+            if !Self::is_line_in_ranges(line, disabled_ranges) {
                 self.add_warning(line, msg);
             }
         }
@@ -766,8 +1224,8 @@ impl<'a> Serializer<'a> {
         ranges
     }
 
-    /// Check if a line number falls within any of the disabled ranges.
-    fn is_line_in_disabled_ranges(line: usize, ranges: &[(usize, usize)]) -> bool {
+    /// Check if a line number falls within any of the given inclusive ranges.
+    fn is_line_in_ranges(line: usize, ranges: &[(usize, usize)]) -> bool {
         ranges
             .iter()
             .any(|(start, end)| line >= *start && line <= *end)

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -123,7 +123,17 @@ impl<'a> Serializer<'a> {
     /// Returns Some((text, label)) if reference style, None if inline style.
     /// The returned text has newlines normalized to spaces for consistent output.
     fn get_reference_style_info<'b>(&self, node: &'b AstNode<'b>) -> Option<(String, String)> {
-        let source = self.extract_source(node)?;
+        self.get_reference_style_info_shifted(node, 0)
+    }
+
+    /// As [`Self::get_reference_style_info`], for a node whose reported lines
+    /// sit `line_offset` above its real ones.
+    fn get_reference_style_info_shifted<'b>(
+        &self,
+        node: &'b AstNode<'b>,
+        line_offset: usize,
+    ) -> Option<(String, String)> {
+        let source = self.extract_source_shifted(node, line_offset)?;
 
         // Reference style patterns:
         // [text][label] or ![text][label] - full reference

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -40,6 +40,26 @@ fn strip_math_sentinels(mut output: String) -> String {
     output
 }
 
+/// The byte offset of the first `]` that closes a link label, which is to say
+/// the first one a backslash does not escape.  A label may hold either bracket
+/// escaped, as in `[a\]b]`, and cutting it at that bracket would leave a label
+/// that no longer names the same definition.
+fn find_unescaped_close_bracket(text: &str) -> Option<usize> {
+    let mut escaped = false;
+    for (offset, character) in text.char_indices() {
+        if escaped {
+            escaped = false;
+            continue;
+        }
+        match character {
+            '\\' => escaped = true,
+            ']' => return Some(offset),
+            _ => {}
+        }
+    }
+    None
+}
+
 /// Result of serialization including output and any warnings.
 pub struct SerializeResult {
     /// The formatted Markdown output.
@@ -123,11 +143,18 @@ impl<'a> Serializer<'a> {
         let first_bracket = source.find('[')?;
         let chars: Vec<char> = source.chars().collect();
 
-        // Find the closing bracket at depth 0 (the one that closes the text/content part)
+        // Find the closing bracket at depth 0 (the one that closes the text/content part).
+        // A backslash-escaped bracket is part of the text, not a delimiter.
         let mut depth = 0;
+        let mut escaped = false;
         let mut text_end_pos = None;
         for (i, &ch) in chars.iter().enumerate().skip(first_bracket) {
+            if escaped {
+                escaped = false;
+                continue;
+            }
             match ch {
+                '\\' => escaped = true,
                 '[' => depth += 1,
                 ']' => {
                     depth -= 1;
@@ -156,8 +183,8 @@ impl<'a> Serializer<'a> {
 
         // If followed by "[", it's full or collapsed reference style
         if let Some(label_content) = after_close.strip_prefix('[') {
-            // Find the label between [ and ]
-            if let Some(label_end) = label_content.find(']') {
+            // Find the label between [ and ], again past any escaped bracket
+            if let Some(label_end) = find_unescaped_close_bracket(label_content) {
                 let label = label_content[..label_end].to_string();
                 // Normalize label too
                 let label = escape::normalize_whitespace(&label);

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -181,7 +181,13 @@ impl<'a> Serializer<'a> {
 
     /// Ensure output ends with a blank line (two newlines).
     /// Used before emitting reference definitions and footnotes.
+    ///
+    /// Empty output needs no separator: a document must not start with blank
+    /// lines just because its first emitted thing is a definition.
     fn ensure_blank_line(&mut self) {
+        if self.output.is_empty() {
+            return;
+        }
         if !self.output.ends_with("\n\n") {
             if self.output.ends_with('\n') {
                 self.output.push('\n');

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -40,11 +40,13 @@ fn strip_math_sentinels(mut output: String) -> String {
     output
 }
 
-/// The byte offset of the first `]` that closes a link label, which is to say
-/// the first one a backslash does not escape.  A label may hold either bracket
-/// escaped, as in `[a\]b]`, and cutting it at that bracket would leave a label
-/// that no longer names the same definition.
-fn find_unescaped_close_bracket(text: &str) -> Option<usize> {
+/// The byte offset of the first `delimiter` a backslash does not escape.
+///
+/// A link label may hold either bracket escaped, as in `[a\]b]`, and cutting it
+/// at that bracket would leave a label that no longer names the same
+/// definition.  The same rule decides where a definition's label ends, so both
+/// readings share this one.
+pub(super) fn find_unescaped(text: &str, delimiter: char) -> Option<usize> {
     let mut escaped = false;
     for (offset, character) in text.char_indices() {
         if escaped {
@@ -53,7 +55,7 @@ fn find_unescaped_close_bracket(text: &str) -> Option<usize> {
         }
         match character {
             '\\' => escaped = true,
-            ']' => return Some(offset),
+            _ if character == delimiter => return Some(offset),
             _ => {}
         }
     }
@@ -194,7 +196,7 @@ impl<'a> Serializer<'a> {
         // If followed by "[", it's full or collapsed reference style
         if let Some(label_content) = after_close.strip_prefix('[') {
             // Find the label between [ and ], again past any escaped bracket
-            if let Some(label_end) = find_unescaped_close_bracket(label_content) {
+            if let Some(label_end) = find_unescaped(label_content, ']') {
                 let label = label_content[..label_end].to_string();
                 // Normalize label too
                 let label = escape::normalize_whitespace(&label);

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -197,8 +197,18 @@ impl<'a> Serializer<'a> {
         }
     }
 
-    /// Output pending reference definitions and clear them
+    /// Output all pending reference definitions and clear them.
     fn flush_references(&mut self) {
+        self.flush_references_before(None);
+    }
+
+    /// Output the pending reference definitions, along with the queued
+    /// definitions of copied links that the source places before `before_line`.
+    fn flush_references_before(&mut self, before_line: Option<usize>) {
+        // Definitions that copied links depend on join the pending ones here,
+        // behind whatever the document's own links registered before them.
+        self.take_deferred_references(before_line);
+
         if self.pending_references.is_empty() {
             return;
         }

--- a/src/serializer/state.rs
+++ b/src/serializer/state.rs
@@ -23,6 +23,9 @@ pub enum FormatSkipMode {
     UntilSection,
     /// Formatting is disabled (by `hongdown-disable` directive).
     /// Remains active until `hongdown-enable` directive is encountered.
+    ///
+    /// Only used when the original source is unavailable: with a source the
+    /// whole region is copied from it in one piece instead.
     Disabled,
 }
 
@@ -316,6 +319,18 @@ pub struct Serializer<'a> {
     pub numbered_reference_labels: std::collections::HashMap<(String, String, String), String>,
     /// Footnote definitions and their reference tracking
     pub footnotes: FootnoteSet,
+    /// Normalized keys (see `normalize_reference_key`) of the definitions that
+    /// are copied verbatim along with a disabled region, and so must not be
+    /// reserved and emitted a second time.
+    pub verbatim_reference_labels: std::collections::HashSet<String>,
+    /// Labels claimed by links that are preserved verbatim, keyed by their
+    /// normalized key.  Such a link cannot be relabelled, so it holds its label
+    /// against formatted links, which can be given a derived one instead.
+    pub verbatim_reference_claims: std::collections::HashMap<String, ReferenceLink>,
+    /// Normalized keys of the labels a verbatim copy redefines: their winning
+    /// definition lies outside it, so it has to be emitted ahead of the copy or
+    /// the copy would shadow it.
+    pub shadowed_reference_labels: std::collections::HashSet<String>,
     /// Current list nesting depth (0 = not in list, 1 = top-level, 2+ = nested)
     pub list_depth: usize,
     /// Current formatting skip mode
@@ -372,6 +387,9 @@ impl<'a> Serializer<'a> {
             reference_label_cursors: std::collections::HashMap::new(),
             numbered_reference_labels: std::collections::HashMap::new(),
             footnotes: FootnoteSet::new(),
+            verbatim_reference_labels: std::collections::HashSet::new(),
+            verbatim_reference_claims: std::collections::HashMap::new(),
+            shadowed_reference_labels: std::collections::HashSet::new(),
             list_depth: 0,
             skip_mode: FormatSkipMode::None,
             in_description_details: false,
@@ -412,6 +430,9 @@ impl<'a> Serializer<'a> {
             reference_label_cursors: std::collections::HashMap::new(),
             numbered_reference_labels: std::collections::HashMap::new(),
             footnotes: FootnoteSet::new(),
+            verbatim_reference_labels: std::collections::HashSet::new(),
+            verbatim_reference_claims: std::collections::HashMap::new(),
+            shadowed_reference_labels: std::collections::HashSet::new(),
             list_depth: 0,
             skip_mode: FormatSkipMode::None,
             in_description_details: false,
@@ -484,6 +505,21 @@ impl<'a> Serializer<'a> {
         Some(result)
     }
 
+    /// Extract original source text for an inclusive range of lines.
+    /// Line numbers are 1-indexed; `end_line` is clamped to the last line.
+    /// Returns `None` when there is no source or the range is empty.
+    pub fn extract_source_lines(&self, start_line: usize, end_line: usize) -> Option<String> {
+        if self.source_lines.is_empty() || start_line == 0 || end_line < start_line {
+            return None;
+        }
+        let start_idx = start_line - 1;
+        if start_idx >= self.source_lines.len() {
+            return None;
+        }
+        let end_idx = (end_line - 1).min(self.source_lines.len() - 1);
+        Some(self.source_lines[start_idx..=end_idx].join("\n"))
+    }
+
     /// Extract original source text from a given line to the end of the file.
     /// Line numbers are 1-indexed.
     pub fn extract_source_from_line(&self, start_line: usize) -> Option<String> {
@@ -522,6 +558,15 @@ impl<'a> Serializer<'a> {
             .or_else(|| self.footnotes.pending_references.get(key).map(|(r, _)| r))
     }
 
+    /// Look up whatever holds `key`, including a label merely claimed by a link
+    /// that is preserved verbatim.  A claim counts as occupying the label even
+    /// before the definition is reserved, because the claiming link cannot be
+    /// relabelled and so must not have its label taken from under it.
+    fn find_occupant(&self, key: &str) -> Option<&ReferenceLink> {
+        self.find_reference(key)
+            .or_else(|| self.verbatim_reference_claims.get(key))
+    }
+
     /// Register a reference link and return the label that must be used to
     /// refer to it.
     ///
@@ -536,7 +581,11 @@ impl<'a> Serializer<'a> {
     /// reference line for proper flush timing.
     pub fn register_reference(&mut self, label: &str, url: &str, title: &str) -> String {
         let key = normalize_reference_key(label);
-        match self.find_reference(&key) {
+        // Copy the occupant out of the borrow so the maps below can be updated.
+        let occupant = self
+            .find_occupant(&key)
+            .map(|existing| (existing.url.clone(), existing.title.clone()));
+        match occupant {
             // Free label: take it.
             None => {
                 self.insert_reference(key, label.to_string(), url, title);
@@ -545,7 +594,12 @@ impl<'a> Serializer<'a> {
             // Already registered with the same target: share it.  The existing
             // entry is left untouched so that its spelling (and, once emitted,
             // its definition) is not duplicated or altered.
-            Some(existing) if existing.url == url && existing.title == title => label.to_string(),
+            Some((occupied_url, occupied_title))
+                if occupied_url == url && occupied_title == title =>
+            {
+                self.satisfy_claimed_label(key, label, url, title);
+                label.to_string()
+            }
             // Taken by a different target: derive a distinct label.
             Some(_) => {
                 // The variants live in the namespace of the shortened base, so
@@ -573,7 +627,7 @@ impl<'a> Serializer<'a> {
                     // Copy the occupant out of the borrow so the maps below can
                     // be updated.
                     let occupant = self
-                        .find_reference(&candidate_key)
+                        .find_occupant(&candidate_key)
                         .map(|existing| (existing.url.clone(), existing.title.clone()));
                     match occupant {
                         // Occupied by something else.  Remember what, because
@@ -589,7 +643,9 @@ impl<'a> Serializer<'a> {
                             continue;
                         }
                         // Already holds this very target: share it.
-                        Some(_) => {}
+                        Some(_) => {
+                            self.satisfy_claimed_label(candidate_key, &candidate, url, title)
+                        }
                         None => self.insert_reference(candidate_key, candidate.clone(), url, title),
                     }
                     self.reference_label_cursors.insert(cursor_key, n + 1);
@@ -599,6 +655,37 @@ impl<'a> Serializer<'a> {
                 }
                 unreachable!("the numbered label space is unbounded")
             }
+        }
+    }
+
+    /// Register a definition for a label that so far is only *claimed*.
+    ///
+    /// A claim marks the label as spoken for by a link preserved verbatim, but
+    /// emits no definition of its own, so a formatted link sharing that label
+    /// still has to supply one.  The exception is a label whose definition is
+    /// preserved verbatim too: that copy already defines it, and adding another
+    /// would merely repeat it.
+    fn satisfy_claimed_label(&mut self, key: String, label: &str, url: &str, title: &str) {
+        if self.find_reference(&key).is_none() && !self.verbatim_reference_labels.contains(&key) {
+            self.insert_reference(key, label.to_string(), url, title);
+        }
+    }
+
+    /// Keep a reference definition alive for a link that is emitted verbatim.
+    ///
+    /// Such a link keeps whatever label the source gave it, so unlike
+    /// [`Self::register_reference`] this never falls back to a derived label:
+    /// a renamed definition would leave the verbatim link pointing at nothing.
+    /// Returns `false` when the label is already taken by a different target,
+    /// which the caller reports as a warning since the link cannot be saved.
+    pub fn reserve_reference(&mut self, label: &str, url: &str, title: &str) -> bool {
+        let key = normalize_reference_key(label);
+        match self.find_reference(&key) {
+            None => {
+                self.insert_reference(key, label.to_string(), url, title);
+                true
+            }
+            Some(existing) => existing.url == url && existing.title == title,
         }
     }
 

--- a/src/serializer/state.rs
+++ b/src/serializer/state.rs
@@ -331,6 +331,12 @@ pub struct Serializer<'a> {
     /// definition lies outside it, so it has to be emitted ahead of the copy or
     /// the copy would shadow it.
     pub shadowed_reference_labels: std::collections::HashSet<String>,
+    /// Definitions that copied links depend on, each with the line its
+    /// definition sits on in the source, which is when it falls due.
+    pub deferred_references: Vec<(ReferenceLink, usize)>,
+    /// Normalized keys of the reference definitions the source carries, mapped
+    /// to the line of the one the parser resolves.
+    pub reference_definition_lines: std::collections::HashMap<String, usize>,
     /// Current list nesting depth (0 = not in list, 1 = top-level, 2+ = nested)
     pub list_depth: usize,
     /// Current formatting skip mode
@@ -390,6 +396,8 @@ impl<'a> Serializer<'a> {
             verbatim_reference_labels: std::collections::HashSet::new(),
             verbatim_reference_claims: std::collections::HashMap::new(),
             shadowed_reference_labels: std::collections::HashSet::new(),
+            deferred_references: Vec::new(),
+            reference_definition_lines: std::collections::HashMap::new(),
             list_depth: 0,
             skip_mode: FormatSkipMode::None,
             in_description_details: false,
@@ -433,6 +441,8 @@ impl<'a> Serializer<'a> {
             verbatim_reference_labels: std::collections::HashSet::new(),
             verbatim_reference_claims: std::collections::HashMap::new(),
             shadowed_reference_labels: std::collections::HashSet::new(),
+            deferred_references: Vec::new(),
+            reference_definition_lines: std::collections::HashMap::new(),
             list_depth: 0,
             skip_mode: FormatSkipMode::None,
             in_description_details: false,
@@ -697,15 +707,63 @@ impl<'a> Serializer<'a> {
     /// a renamed definition would leave the verbatim link pointing at nothing.
     /// Returns `false` when the label is already taken by a different target,
     /// which the caller reports as a warning since the link cannot be saved.
+    ///
+    /// The definition is queued rather than registered at once, and falls due
+    /// where the source put it, the way a footnote's references follow their
+    /// footnote.  A copied link is not the reason its definition sits where it
+    /// does, so letting it claim a place among the pending definitions would
+    /// move that definition around — and where it would land depends on whether
+    /// the parser could resolve the copied link, which is to say on whether an
+    /// earlier run had already written the very definition being reserved.
+    /// Following the source keeps every run agreeing on the placement.
     pub fn reserve_reference(&mut self, label: &str, url: &str, title: &str) -> bool {
         let key = normalize_reference_key(label);
-        match self.find_reference(&key) {
-            None => {
-                self.insert_reference(key, label.to_string(), url, title);
-                true
-            }
-            Some(existing) => existing.url == url && existing.title == title,
+        if let Some(existing) = self.find_reference(&key)
+            && (existing.url != url || existing.title != title)
+        {
+            return false;
         }
+        // A definition the scanner did not find falls due at the end, which is
+        // the one placement that cannot come out ahead of something.
+        let due = self
+            .reference_definition_lines
+            .get(&key)
+            .copied()
+            .unwrap_or(usize::MAX);
+        self.deferred_references.push((
+            ReferenceLink {
+                label: label.to_string(),
+                url: url.to_string(),
+                title: title.to_string(),
+            },
+            due,
+        ));
+        true
+    }
+
+    /// Move the queued definitions that are due before `before_line` into the
+    /// pending ones, behind everything the document's own links registered.
+    /// `None` takes them all, for the flush that ends the document.
+    ///
+    /// A definition already emitted or already pending needs nothing: the first
+    /// is written, and the second is about to be.  One held only by a footnote's
+    /// collection does need this, though, since that collection is flushed on
+    /// the footnote's schedule rather than here.
+    pub fn take_deferred_references(&mut self, before_line: Option<usize>) {
+        let mut deferred = std::mem::take(&mut self.deferred_references);
+        deferred.retain(|(reference, due)| {
+            if before_line.is_some_and(|line| *due >= line) {
+                return true;
+            }
+            let key = normalize_reference_key(&reference.label);
+            if !self.emitted_references.contains_key(&key)
+                && !self.pending_references.contains_key(&key)
+            {
+                self.pending_references.insert(key, reference.clone());
+            }
+            false
+        });
+        self.deferred_references = deferred;
     }
 
     /// Store a new reference definition under an unused key.

--- a/src/serializer/state.rs
+++ b/src/serializer/state.rs
@@ -567,6 +567,18 @@ impl<'a> Serializer<'a> {
             .or_else(|| self.verbatim_reference_claims.get(key))
     }
 
+    /// Whether a verbatim copy carries a definition for `key`.
+    ///
+    /// Such a definition holds the label in the output whether or not anything
+    /// resolves through it, and whether it is the definition the parser
+    /// resolved or a duplicate the copy repeats.  So the label is spoken for
+    /// even when nothing reveals what it points at, and a link that took it
+    /// would find its own definition placed after the copy, where CommonMark's
+    /// first-wins rule would hand it the copy's destination instead.
+    fn is_label_carried_verbatim(&self, key: &str) -> bool {
+        self.verbatim_reference_labels.contains(key) || self.shadowed_reference_labels.contains(key)
+    }
+
     /// Register a reference link and return the label that must be used to
     /// refer to it.
     ///
@@ -586,11 +598,6 @@ impl<'a> Serializer<'a> {
             .find_occupant(&key)
             .map(|existing| (existing.url.clone(), existing.title.clone()));
         match occupant {
-            // Free label: take it.
-            None => {
-                self.insert_reference(key, label.to_string(), url, title);
-                label.to_string()
-            }
             // Already registered with the same target: share it.  The existing
             // entry is left untouched so that its spelling (and, once emitted,
             // its definition) is not duplicated or altered.
@@ -600,8 +607,16 @@ impl<'a> Serializer<'a> {
                 self.satisfy_claimed_label(key, label, url, title);
                 label.to_string()
             }
-            // Taken by a different target: derive a distinct label.
-            Some(_) => {
+            // Free label: take it.
+            None if !self.is_label_carried_verbatim(&key) => {
+                self.insert_reference(key, label.to_string(), url, title);
+                label.to_string()
+            }
+            // Taken: by a different target, or by a definition that a verbatim
+            // copy carries.  A carried definition holds its label document-wide
+            // whether or not a link resolves through it, and its target is
+            // unknown when none does, so its label cannot be shared either.
+            _ => {
                 // The variants live in the namespace of the shortened base, so
                 // that is what both the cursor and the reuse map are keyed by:
                 // labels long enough to be shortened to the same prefix share
@@ -642,6 +657,10 @@ impl<'a> Serializer<'a> {
                                 .or_insert(candidate);
                             continue;
                         }
+                        // Held by a definition a verbatim copy carries, whose
+                        // target is unknown; nothing to remember it by, so the
+                        // search simply moves on.
+                        None if self.is_label_carried_verbatim(&candidate_key) => continue,
                         // Already holds this very target: share it.
                         Some(_) => {
                             self.satisfy_claimed_label(candidate_key, &candidate, url, title)

--- a/src/serializer/state.rs
+++ b/src/serializer/state.rs
@@ -467,12 +467,27 @@ impl<'a> Serializer<'a> {
 
     /// Extract original source text for a node using its sourcepos.
     pub fn extract_source<'b>(&self, node: &'b AstNode<'b>) -> Option<String> {
+        self.extract_source_shifted(node, 0)
+    }
+
+    /// Extract original source text for a node whose reported lines sit
+    /// `line_offset` above its real ones.
+    ///
+    /// An inline inside a paragraph that swallowed a definition at its head is
+    /// reported against the paragraph's own start, so its lines are short by
+    /// however many lines that definition took.  Its columns are the ones its
+    /// real line has.
+    pub fn extract_source_shifted<'b>(
+        &self,
+        node: &'b AstNode<'b>,
+        line_offset: usize,
+    ) -> Option<String> {
         if self.source_lines.is_empty() {
             return None;
         }
         let sourcepos = node.data.borrow().sourcepos;
-        let start_line = sourcepos.start.line;
-        let end_line = sourcepos.end.line;
+        let start_line = sourcepos.start.line + line_offset;
+        let end_line = sourcepos.end.line + line_offset;
         let start_col = sourcepos.start.column;
         let end_col = sourcepos.end.column;
 

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -1702,8 +1702,14 @@ fn test_directive_disable_reservation_precedes_a_setext_heading() {
     // start, but it precedes the heading, so it belongs above the section.
     let input = "<!-- hongdown-disable -->\n\nRaw [a].\n\n<!-- hongdown-enable -->\n\n[a]: https://example.com/first\nSection\n-------\n\nBody.\n";
     let result = parse_and_serialize_with_source(input);
+    let definition = result
+        .find("[a]: https://example.com/first")
+        .expect("the definition must be kept");
+    let section = result
+        .find("Section\n-------")
+        .expect("the section must be emitted");
     assert!(
-        result.find("[a]: https://example.com/first") < result.find("Section\n-------"),
+        definition < section,
         "the definition must come before the section it precedes, got:\n{}",
         result
     );
@@ -1722,8 +1728,12 @@ fn test_directive_disable_reservation_waits_for_its_section() {
     // pulling it up would mean one run never settles the file.
     let input = "<!-- hongdown-disable -->\n\nRaw [a].\n\n<!-- hongdown-enable -->\n\nSection\n-------\n\nLater [a](https://example.com/a).\n";
     let result = parse_and_serialize_with_source(input);
+    let definition = result
+        .find("[a]: https://example.com/a")
+        .expect("the definition must be kept");
+    let section = result.find("Section").expect("the section must be emitted");
     assert!(
-        result.find("[a]: https://example.com/a") > result.find("Section"),
+        definition > section,
         "the definition must stay in the section the source put it in, got:\n{}",
         result
     );
@@ -1755,8 +1765,14 @@ fn test_directive_disable_reservation_keeps_the_definition_order() {
     // settle the file.
     let input = "<!-- hongdown-disable -->\n\nRaw [a].\n\n<!-- hongdown-enable -->\n\nLater [b](https://example.com/b) and [a](https://example.com/a).\n";
     let result = parse_and_serialize_with_source(input);
+    let first = result
+        .find("[b]: https://example.com/b")
+        .expect("the first definition must be kept");
+    let second = result
+        .find("[a]: https://example.com/a")
+        .expect("the second definition must be kept");
     assert!(
-        result.find("[b]: https://example.com/b") < result.find("[a]: https://example.com/a"),
+        first < second,
         "the definitions must follow the order the document's own links set, got:\n{}",
         result
     );
@@ -1936,9 +1952,14 @@ fn test_directive_disable_next_line_reads_a_link_below_a_consumed_definition() {
     // has to come out above the copy that repeats its label.
     let input = "[b]: https://example.com/first\n\n<!-- hongdown-disable-next-line -->\n[b]: https://example.com/second\nRaw [b].\n";
     let result = parse_and_serialize_with_source(input);
+    let winner = result
+        .find("[b]: https://example.com/first")
+        .expect("the winning definition must be kept");
+    let duplicate = result
+        .find("[b]: https://example.com/second")
+        .expect("the region's copy must be preserved");
     assert!(
-        result.find("[b]: https://example.com/first")
-            < result.find("[b]: https://example.com/second"),
+        winner < duplicate,
         "the winning definition must come first, got:\n{}",
         result
     );
@@ -1951,9 +1972,14 @@ fn test_directive_disable_sees_a_definition_below_a_multiline_title() {
     // copy of its label look like the winner.
     let input = "[a]: https://example.com/a \"A title\nspanning lines\"\n[b]: https://example.com/first\nSome prose.\n\n<!-- hongdown-disable -->\n\nRaw [b].\n\n[b]: https://example.com/second\n";
     let result = parse_and_serialize_with_source(input);
+    let winner = result
+        .find("[b]: https://example.com/first")
+        .expect("the winning definition must be kept");
+    let duplicate = result
+        .find("[b]: https://example.com/second")
+        .expect("the region's copy must be preserved");
     assert!(
-        result.find("[b]: https://example.com/first")
-            < result.find("[b]: https://example.com/second"),
+        winner < duplicate,
         "the winning definition must come first, got:\n{}",
         result
     );
@@ -1966,9 +1992,14 @@ fn test_directive_disable_sees_a_definition_below_a_three_line_title() {
     // definition beneath from the scanner.
     let input = "[a]: https://example.com/a \"A title\nspanning three\nlines\"\n[b]: https://example.com/first\nSome prose.\n\n<!-- hongdown-disable -->\n\nRaw [b].\n\n[b]: https://example.com/second\n";
     let result = parse_and_serialize_with_source(input);
+    let winner = result
+        .find("[b]: https://example.com/first")
+        .expect("the winning definition must be kept");
+    let duplicate = result
+        .find("[b]: https://example.com/second")
+        .expect("the region's copy must be preserved");
     assert!(
-        result.find("[b]: https://example.com/first")
-            < result.find("[b]: https://example.com/second"),
+        winner < duplicate,
         "the winning definition must come first, got:\n{}",
         result
     );
@@ -2121,9 +2152,14 @@ fn test_directive_disable_sees_a_definition_below_a_title_of_its_own_line() {
     // allows.  The definition beneath it still has to be found.
     let input = "[a]: https://example.com/a\n  \"A title\"\n[b]: https://example.com/first\nSome prose.\n\n<!-- hongdown-disable -->\n\nRaw [b].\n\n[b]: https://example.com/second\n";
     let result = parse_and_serialize_with_source(input);
+    let winner = result
+        .find("[b]: https://example.com/first")
+        .expect("the winning definition must be kept");
+    let duplicate = result
+        .find("[b]: https://example.com/second")
+        .expect("the region's copy must be preserved");
     assert!(
-        result.find("[b]: https://example.com/first")
-            < result.find("[b]: https://example.com/second"),
+        winner < duplicate,
         "the winning definition must come first, got:\n{}",
         result
     );
@@ -2135,9 +2171,14 @@ fn test_directive_disable_sees_a_definition_below_a_title_running_on() {
     // further line before it closes.
     let input = "[a]: https://example.com/a\n  \"A title\nspanning lines\"\n[b]: https://example.com/first\nSome prose.\n\n<!-- hongdown-disable -->\n\nRaw [b].\n\n[b]: https://example.com/second\n";
     let result = parse_and_serialize_with_source(input);
+    let winner = result
+        .find("[b]: https://example.com/first")
+        .expect("the winning definition must be kept");
+    let duplicate = result
+        .find("[b]: https://example.com/second")
+        .expect("the region's copy must be preserved");
     assert!(
-        result.find("[b]: https://example.com/first")
-            < result.find("[b]: https://example.com/second"),
+        winner < duplicate,
         "the winning definition must come first, got:\n{}",
         result
     );
@@ -2149,9 +2190,14 @@ fn test_directive_disable_title_is_not_closed_by_an_escaped_quote() {
     // title still runs to the line below.
     let input = "[a]: https://example.com/a \"A \\\"quoted\\\" title\nspanning lines\"\n[b]: https://example.com/first\nSome prose.\n\n<!-- hongdown-disable -->\n\nRaw [b].\n\n[b]: https://example.com/second\n";
     let result = parse_and_serialize_with_source(input);
+    let winner = result
+        .find("[b]: https://example.com/first")
+        .expect("the winning definition must be kept");
+    let duplicate = result
+        .find("[b]: https://example.com/second")
+        .expect("the region's copy must be preserved");
     assert!(
-        result.find("[b]: https://example.com/first")
-            < result.find("[b]: https://example.com/second"),
+        winner < duplicate,
         "the winning definition must come first, got:\n{}",
         result
     );

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -1588,6 +1588,186 @@ fn test_directive_disable_sees_definitions_after_a_multiline_one() {
 }
 
 #[test]
+fn test_directive_disable_shadowed_definition_beats_a_footnote_schedule() {
+    // The winning definition is only spoken for by a footnote referenced after
+    // the region, and that collection is flushed on the footnote's schedule.
+    // It still has to come out ahead of the copy that redefines the label.
+    let input = "[a]: https://example.com/first\n\nIntro [a].\n\n<!-- hongdown-disable -->\n\nRaw [a].\n\n[a]: https://example.com/second\n\n<!-- hongdown-enable -->\n\nText[^1].\n\n[^1]: See [a].\n";
+    let result = parse_and_serialize_with_source(input);
+    let winner = result
+        .find("[a]: https://example.com/first")
+        .expect("the winning definition must be kept");
+    let duplicate = result
+        .find("[a]: https://example.com/second")
+        .expect("the region's copy must be preserved");
+    assert!(
+        winner < duplicate,
+        "the winning definition must come first, got:\n{}",
+        result
+    );
+    assert_eq!(
+        result.matches("[a]: https://example.com/first").count(),
+        1,
+        "and only once, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_sees_a_definition_a_setext_heading_swallowed() {
+    // A setext heading keeps the lines of a definition consumed at its head,
+    // just as a paragraph does.  Overlooking it would make the region's copy
+    // the apparent winner and retarget the links.
+    let input = "[a]: https://example.com/first\nHeading\n=======\n\nIntro [a].\n\n<!-- hongdown-disable -->\n\nRaw [a].\n\n[a]: https://example.com/second\n";
+    let result = parse_and_serialize_with_source(input);
+    let winner = result
+        .find("[a]: https://example.com/first")
+        .expect("the winning definition must be kept");
+    let duplicate = result
+        .find("[a]: https://example.com/second")
+        .expect("the region's copy must be preserved");
+    assert!(
+        winner < duplicate,
+        "the winning definition must come first, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_next_line_survives_a_noun_directive() {
+    // A directive that only names nouns leaves the skip in place, so the block
+    // after it is still the one copied, along with the definition at its head.
+    let input = "<!-- hongdown-disable-next-line -->\n<!-- hongdown-proper-nouns: Foo -->\n[a]: https://example.com/copied\nSome   prose.\n\nLater [a](https://example.com/other).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("Later [a][a 2].") && result.contains("[a 2]: https://example.com/other"),
+        "the copied definition must hold its label, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_next_line_survives_a_footnote_definition() {
+    // A footnote definition is emitted by the footnote machinery rather than
+    // copied, so it does not consume the skip either.
+    let input = "Text[^1].\n\n<!-- hongdown-disable-next-line -->\n\n[^1]: Note.\n\n[a]: https://example.com/copied\nSome   prose.\n\nLater [a](https://example.com/other).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("Later [a][a 2].") && result.contains("[a 2]: https://example.com/other"),
+        "the copied definition must hold its label, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_next_section_ends_at_an_enable() {
+    // `hongdown-enable` ends a section-wide skip, so what follows is formatted
+    // and its definitions are not carried by any copy.
+    let input = "<!-- hongdown-disable-next-section -->\n\nRaw   text.\n\n<!-- hongdown-enable -->\n\n[a]: https://example.com/plain\nSome prose.\n\nLater [a](https://example.com/other).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("Raw   text."),
+        "the skipped block must keep its spacing, got:\n{}",
+        result
+    );
+    assert!(
+        result.contains("Later [a].") && result.contains("[a]: https://example.com/other"),
+        "the label is free after the enable, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_next_line_copy_carries_its_head_definition() {
+    // The block is copied by its source span, which reaches back over the
+    // definition consumed at its head, so the copy defines that label too and
+    // a later link must not take it.
+    let input = "<!-- hongdown-disable-next-line -->\n[a]: https://example.com/copied\nSome   prose.\n\nLater [a](https://example.com/other).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("Later [a][a 2].") && result.contains("[a 2]: https://example.com/other"),
+        "the later link must keep its own destination, got:\n{}",
+        result
+    );
+    assert_eq!(
+        parse_and_serialize_with_source(&result),
+        result,
+        "formatting must be idempotent"
+    );
+}
+
+#[test]
+fn test_directive_disable_reservation_precedes_a_setext_heading() {
+    // The definition sits on the line a setext heading reports as its own
+    // start, but it precedes the heading, so it belongs above the section.
+    let input = "<!-- hongdown-disable -->\n\nRaw [a].\n\n<!-- hongdown-enable -->\n\n[a]: https://example.com/first\nSection\n-------\n\nBody.\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.find("[a]: https://example.com/first") < result.find("Section\n-------"),
+        "the definition must come before the section it precedes, got:\n{}",
+        result
+    );
+    assert_eq!(
+        parse_and_serialize_with_source(&result),
+        result,
+        "formatting must be idempotent"
+    );
+}
+
+#[test]
+fn test_directive_disable_reservation_waits_for_its_section() {
+    // The definition the copied link needs sits after a section boundary, so
+    // reserving it must not pull it up to that boundary.  It is a link only on
+    // the second run, when the first has already written the definition, so
+    // pulling it up would mean one run never settles the file.
+    let input = "<!-- hongdown-disable -->\n\nRaw [a].\n\n<!-- hongdown-enable -->\n\nSection\n-------\n\nLater [a](https://example.com/a).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.find("[a]: https://example.com/a") > result.find("Section"),
+        "the definition must stay in the section the source put it in, got:\n{}",
+        result
+    );
+    assert_eq!(
+        parse_and_serialize_with_source(&result),
+        result,
+        "one pass must settle the file"
+    );
+}
+
+#[test]
+fn test_directive_disable_reservation_keeps_its_section() {
+    // Nothing outside the region uses these labels, so the reservation decides
+    // where they go.  It follows the source, which puts them at the end of the
+    // region's own section rather than at the end of the document.
+    let input = "Section one\n-----------\n\n<!-- hongdown-disable -->\n\n[![B][img]][url]\n\n<!-- hongdown-enable -->\n\n[img]: https://example.com/i.svg\n[url]: https://example.com/u\n\n\nSection two\n-----------\n\nText.\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result, input,
+        "the definitions must stay in their own section"
+    );
+}
+
+#[test]
+fn test_directive_disable_reservation_keeps_the_definition_order() {
+    // `[a]` in the region resolves only once the formatter has defined it, so
+    // it is a link on the second run and not on the first.  Reserving it must
+    // not therefore move its definition ahead of `[b]`, or one run would not
+    // settle the file.
+    let input = "<!-- hongdown-disable -->\n\nRaw [a].\n\n<!-- hongdown-enable -->\n\nLater [b](https://example.com/b) and [a](https://example.com/a).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.find("[b]: https://example.com/b") < result.find("[a]: https://example.com/a"),
+        "the definitions must follow the order the document's own links set, got:\n{}",
+        result
+    );
+    assert_eq!(
+        parse_and_serialize_with_source(&result),
+        result,
+        "one pass must settle the file"
+    );
+}
+
+#[test]
 fn test_directive_disable_rejects_a_malformed_definition_lookalike() {
     // Neither line is a definition — the parser leaves both inside a paragraph
     // — so the real definition must survive.

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -1281,6 +1281,351 @@ fn test_directive_disable_enable() {
 }
 
 #[test]
+fn test_directive_disable_preserves_reference_definition() {
+    // A reference definition inside a disabled region has no AST node of its
+    // own, but it must still survive: dropping it leaves the region's links
+    // pointing at nothing.
+    let input = "Intro.\n\n<!-- hongdown-disable -->\n\nPreserved [guide] here.\n\n[guide]: https://example.com/preserved\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result, input,
+        "a disabled region must keep its own reference definition"
+    );
+}
+
+#[test]
+fn test_directive_disable_preserves_region_verbatim() {
+    // Everything between the directives is copied from the source, so
+    // indentation and blank lines inside the region are kept as they were.
+    let input = "Intro.\n\n<!-- hongdown-disable -->\n\n  Indented   [a] line.\n\n\n[a]: https://example.com/a\n[b]: https://example.com/b \"Title\"\n\nUses [b] too.\n\n<!-- hongdown-enable -->\n\nBack.\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result, input,
+        "a disabled region must be preserved verbatim"
+    );
+}
+
+#[test]
+fn test_directive_disable_keeps_definitions_defined_outside() {
+    // The definitions live after the region, so they cannot be copied with it;
+    // the region's links must still keep them from being dropped.
+    let input = "Normal paragraph.\n\n<!-- hongdown-disable -->\n\n[![Badge][img]][url]\n\n<!-- hongdown-enable -->\n\nBack to normal formatting.\n\n[img]: https://example.com/img.svg\n[url]: https://example.com\n";
+    let result = parse_and_serialize_with_source(input);
+    // Definitions keep the order the formatted path would give them: the
+    // badge's image is registered before the link wrapping it.
+    assert_eq!(
+        result, input,
+        "definitions used only inside a disabled region must be kept"
+    );
+}
+
+#[test]
+fn test_directive_disable_without_source_still_skips_formatting() {
+    // Without the original source there is nothing to copy, so the region
+    // falls back to emitting its blocks one by one.
+    let input = "Normal.\n\n<!-- hongdown-disable -->\n\nUnformatted.\n\n<!-- hongdown-enable -->\n\nBack.\n";
+    let result = parse_and_serialize(input);
+    assert!(
+        result.contains("Unformatted."),
+        "the region's content must survive without a source, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_link_keeps_its_label_against_a_formatted_one() {
+    // Both links want the label `guide` for different destinations.  The one
+    // inside the region is copied verbatim and cannot be relabelled, so the
+    // formatted link is the one that takes a derived label.
+    let input = "[guide](https://example.com/first)\n\n<!-- hongdown-disable -->\n\nSee [guide] here.\n\n<!-- hongdown-enable -->\n\n[guide]: https://example.com/second\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert_eq!(
+        result.output,
+        "[guide][guide 2]\n\n[guide 2]: https://example.com/first\n\n<!-- hongdown-disable -->\n\nSee [guide] here.\n\n<!-- hongdown-enable -->\n\n[guide]: https://example.com/second\n",
+        "the verbatim link must keep its label and both destinations must survive"
+    );
+    assert!(
+        result.warnings.is_empty(),
+        "the collision is resolvable, so nothing should be reported: {:?}",
+        result.warnings
+    );
+    assert_eq!(
+        parse_and_serialize_with_source(&result.output),
+        result.output,
+        "formatting must be idempotent"
+    );
+}
+
+#[test]
+fn test_directive_disable_file_keeps_definitions_defined_before() {
+    // The tail keeps its source text, so a definition placed before the
+    // directive is only kept if the tail's links reserve it.
+    let input = "Intro.\n\n<!-- hongdown-disable-file -->\n\nRaw   [guide] text.\n";
+    let source = format!("[guide]: https://example.com/guide\n\n{}", input);
+    let result = parse_and_serialize_with_source(&source);
+    assert!(
+        result.contains("[guide]: https://example.com/guide"),
+        "a definition the disabled tail depends on must be kept, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_keeps_a_duplicated_definition_inert() {
+    // The region's copy repeats a label that is already defined above it.
+    // CommonMark resolves both links through the first definition, so that one
+    // has to stay first in the output or the links would be retargeted.
+    let input = "Intro [g].\n\n[g]: https://example.com/first\n\n<!-- hongdown-disable -->\n\nRaw [g].\n\n[g]: https://example.com/second\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result, input,
+        "the winning definition must stay ahead of the copied duplicate"
+    );
+}
+
+#[test]
+fn test_directive_disable_keeps_a_multiline_definition_ahead_of_its_duplicate() {
+    // The winning definition spells its destination on the following line, as
+    // CommonMark allows.  Overlooking it would make the region's duplicate look
+    // like the winner and let the copy retarget the link.
+    let input = "Intro.\n\n[g]:\n    https://example.com/first\n\n<!-- hongdown-disable -->\n\nRaw [g].\n\n[g]: https://example.com/second\n";
+    let result = parse_and_serialize_with_source(input);
+    let winner = result
+        .find("[g]: https://example.com/first")
+        .expect("the winning definition must be kept");
+    let duplicate = result
+        .find("[g]: https://example.com/second")
+        .expect("the region's copy must be preserved");
+    assert!(
+        winner < duplicate,
+        "the winning definition must come first, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_definition_inside_region_is_not_duplicated() {
+    // The definition is copied with the region and also serves a link outside
+    // it; the outside link must reuse that copy rather than emit its own.
+    let input =
+        "Intro [g].\n\n<!-- hongdown-disable -->\n\nRaw [g].\n\n[g]: https://example.com/url\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result.matches("[g]: ").count(),
+        1,
+        "the definition must appear exactly once, got:\n{}",
+        result
+    );
+    assert_eq!(result, input, "the region must be preserved verbatim");
+}
+
+#[test]
+fn test_directive_disable_ignores_definitions_inside_code_blocks() {
+    // A definition-looking line inside a fenced code block in the region is
+    // not a definition, so the real one outside must still be kept.
+    let input = "Intro.\n\n<!-- hongdown-disable -->\n\nSee [guide] here.\n\n~~~~ markdown\n[guide]: https://example.com/not-a-definition\n~~~~\n\n<!-- hongdown-enable -->\n\n[guide]: https://example.com/real\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("[guide]: https://example.com/real"),
+        "a definition must not be considered preserved by a code block, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_ignores_definitions_inside_html_blocks() {
+    // Raw HTML is not Markdown either, so a definition-looking line in it does
+    // not stand in for the real definition outside the region.
+    let input = "Intro.\n\n<!-- hongdown-disable -->\n\nSee [guide] here.\n\n<pre>\n[guide]: https://example.com/not-a-definition\n</pre>\n\n<!-- hongdown-enable -->\n\n[guide]: https://example.com/real\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("[guide]: https://example.com/real"),
+        "a definition must not be considered preserved by an HTML block, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_ignores_a_bare_label_that_defines_nothing() {
+    // `[foo]:` only defines something when the next line supplies a
+    // destination.  Here it does not, so the real definition must still be kept.
+    let input = "Intro.\n\n<!-- hongdown-disable -->\n\nSee [foo] here.\n\nA line\n[foo]:\nnot a destination at all\n\n<!-- hongdown-enable -->\n\n[foo]: https://example.com/real\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("[foo]: https://example.com/real"),
+        "a label that defines nothing must not stand in for the definition, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_sees_a_blockquoted_definition_in_the_region() {
+    // A definition under a blockquote prefix is still a definition, and it is
+    // copied with the region, so it must not also be emitted outside it.
+    let input = "Intro.\n\n<!-- hongdown-disable -->\n\n> Quoted [g] link.\n>\n> [g]: https://example.com/quoted\n\n<!-- hongdown-enable -->\n\nEnd.\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result.matches("[g]: ").count(),
+        1,
+        "the definition must appear exactly once, got:\n{}",
+        result
+    );
+    assert_eq!(result, input, "the region must be preserved verbatim");
+}
+
+#[test]
+fn test_directive_disable_rejects_an_unterminated_pointy_destination() {
+    // `<unterminated` cannot be a destination, so the bare label above it
+    // defines nothing and the real definition must survive.
+    let input = "Intro.\n\n<!-- hongdown-disable -->\n\nSee [g].\n\nline\n[g]:\n<unterminated\n\n<!-- hongdown-enable -->\n\n[g]: https://example.com/real\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("[g]: https://example.com/real"),
+        "the real definition must survive, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_rejects_a_malformed_same_line_destination() {
+    // The destination on the label's own line is checked just as closely:
+    // unbalanced parentheses make it no destination at all.
+    let input = "Intro.\n\n<!-- hongdown-disable -->\n\nSee [g].\n\nprose\n[g]: foo(bar\n\n<!-- hongdown-enable -->\n\n[g]: https://example.com/real\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("[g]: https://example.com/real"),
+        "the real definition must survive, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_accepts_a_destination_with_balanced_parentheses() {
+    // Balanced parentheses are ordinary in URLs, so the definition is real and
+    // is copied with the region rather than emitted a second time outside it.
+    let input = "Intro.\n\n<!-- hongdown-disable -->\n\nSee [w].\n\n[w]: https://en.wikipedia.org/wiki/Foo_(bar)\n\n<!-- hongdown-enable -->\n\nEnd.\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result.matches("[w]: ").count(),
+        1,
+        "the definition must appear exactly once, got:\n{}",
+        result
+    );
+    assert_eq!(result, input, "the region must be preserved verbatim");
+}
+
+#[test]
+fn test_directive_disable_separates_a_definition_from_the_directive() {
+    // The definition is flushed above the region because the copy redefines the
+    // label, and it has no node of its own for the child index to count.
+    let input = "[g]: https://example.com/first\n\n<!-- hongdown-disable -->\n\nRaw [g].\n\n[g]: https://example.com/second\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result, input,
+        "the directive must not run into the definition above it"
+    );
+}
+
+#[test]
+fn test_directive_after_front_matter_gets_one_blank_line() {
+    // Front matter already ends with a blank line, so the directive must not
+    // add another one on top of it.
+    let input = "---\ntitle: Test\n---\n\n<!-- hongdown-disable-next-line -->\n\nSome   text.\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result, input,
+        "a directive after front matter must be separated by one blank line"
+    );
+}
+
+#[test]
+fn test_directive_disable_file_definition_does_not_add_leading_blank_lines() {
+    // The definition is the only thing before the directive, and it has no node
+    // of its own, so the document would start with the flush that emits it.
+    let input = "[g]: https://example.com/g\n\n<!-- hongdown-disable-file -->\n\nRaw   [g] text.\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result, input,
+        "a document must not gain leading blank lines"
+    );
+}
+
+#[test]
+fn test_directive_disable_next_line_keeps_definitions() {
+    // Same loss through a different directive: the badge is emitted verbatim,
+    // so nothing registers the definitions it depends on.
+    let input = "<!-- hongdown-disable-next-line -->\n[![Badge][badge-img]][badge-url]\n\n[badge-img]: https://example.com/badge.svg\n[badge-url]: https://example.com\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("[badge-img]: https://example.com/badge.svg"),
+        "disable-next-line must keep the definitions its block uses, got:\n{}",
+        result
+    );
+    assert!(
+        result.contains("[badge-url]: https://example.com"),
+        "disable-next-line must keep the definitions its block uses, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_next_section_keeps_definitions() {
+    // Without a following heading the whole rest of the document is skipped,
+    // so its links are the only users of the definitions.
+    let input = "Intro.\n\n<!-- hongdown-disable-next-section -->\n\nPreserved [guide] here.\n\n[guide]: https://example.com/preserved\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("[guide]: https://example.com/preserved"),
+        "disable-next-section must keep the definitions its content uses, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_preserves_footnote_definition_in_place() {
+    // A footnote definition inside the region is copied with the region, so it
+    // must not also be re-emitted by the footnote flush.
+    let input = "Intro.\n\n<!-- hongdown-disable -->\n\nPara[^1].\n\n[^1]: The   note.\n\n<!-- hongdown-enable -->\n\nAfter.\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result.matches("[^1]:").count(),
+        1,
+        "the footnote definition must not be duplicated, got:\n{}",
+        result
+    );
+    assert_eq!(
+        result, input,
+        "a footnote definition inside a disabled region stays where it was"
+    );
+}
+
+#[test]
+fn test_directive_disable_keeps_trailing_comment_once() {
+    // A trailing HTML comment inside the region is part of the verbatim copy
+    // and must not be emitted a second time after the references.
+    let input = "Intro.\n\n<!-- hongdown-disable -->\n\nPara.\n\n<!-- a comment -->\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result.matches("<!-- a comment -->").count(),
+        1,
+        "the trailing comment must not be duplicated, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_definition_used_on_both_sides() {
+    // The definition sits outside the region and is used from both sides; it
+    // must stay where the formatter normally puts it, exactly once.
+    let input = "Intro.\n\n<!-- hongdown-disable -->\n\nPreserved [guide] here.\n\n<!-- hongdown-enable -->\n\nAfter [guide] too.\n\n[guide]: https://example.com/preserved\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result, input,
+        "the shared definition must be kept exactly once"
+    );
+}
+
+#[test]
 fn test_preserve_reference_style_badge() {
     // Reference-style badge links should be preserved as reference style
     let input = "[![JSR][JSR badge]][JSR]\n\n[JSR]: https://jsr.io/@optique\n[JSR badge]: https://jsr.io/badges/@optique/core";

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -1447,14 +1447,33 @@ fn test_directive_disable_ignores_definitions_inside_html_blocks() {
 
 #[test]
 fn test_directive_disable_ignores_a_bare_label_that_defines_nothing() {
-    // `[foo]:` only defines something when the next line supplies a
-    // destination.  Here it does not, so the real definition must still be kept.
+    // `[foo]:` here is a continuation line of a paragraph, not a definition, so
+    // the real definition must still be kept.
     let input = "Intro.\n\n<!-- hongdown-disable -->\n\nSee [foo] here.\n\nA line\n[foo]:\nnot a destination at all\n\n<!-- hongdown-enable -->\n\n[foo]: https://example.com/real\n";
     let result = parse_and_serialize_with_source(input);
     assert!(
         result.contains("[foo]: https://example.com/real"),
         "a label that defines nothing must not stand in for the definition, got:\n{}",
         result
+    );
+}
+
+#[test]
+fn test_directive_disable_ignores_a_definition_lookalike_in_a_paragraph() {
+    // The line inside the region continues a paragraph, so it defines nothing.
+    // Taking it for the winning definition would suppress the real one and
+    // leave both links pointing at nothing.
+    let input = "Formatted [g] link.\n\n<!-- hongdown-disable -->\n\nThis is prose\n[g]: https://example.com/not-a-definition\n\n<!-- hongdown-enable -->\n\nEnd.\n\n[g]: https://example.com/real\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("[g]: https://example.com/real"),
+        "the real definition must survive, got:\n{}",
+        result
+    );
+    assert_eq!(
+        parse_and_serialize_with_source(&result),
+        result,
+        "formatting must be idempotent"
     );
 }
 
@@ -1474,10 +1493,11 @@ fn test_directive_disable_sees_a_blockquoted_definition_in_the_region() {
 }
 
 #[test]
-fn test_directive_disable_rejects_an_unterminated_pointy_destination() {
-    // `<unterminated` cannot be a destination, so the bare label above it
-    // defines nothing and the real definition must survive.
-    let input = "Intro.\n\n<!-- hongdown-disable -->\n\nSee [g].\n\nline\n[g]:\n<unterminated\n\n<!-- hongdown-enable -->\n\n[g]: https://example.com/real\n";
+fn test_directive_disable_ignores_a_definition_lookalike_in_a_code_span() {
+    // A code span holding a newline spans lines without a break node, so the
+    // line count alone would expose the line above it.  It is paragraph content
+    // all the same, and the real definition must survive.
+    let input = "Formatted [g] link.\n\n<!-- hongdown-disable -->\n\nSee [g] and `code\n[g]: not-a-definition\nspan`\n\n<!-- hongdown-enable -->\n\nEnd.\n\n[g]: https://example.com/real\n";
     let result = parse_and_serialize_with_source(input);
     assert!(
         result.contains("[g]: https://example.com/real"),
@@ -1487,10 +1507,50 @@ fn test_directive_disable_rejects_an_unterminated_pointy_destination() {
 }
 
 #[test]
-fn test_directive_disable_rejects_a_malformed_same_line_destination() {
-    // The destination on the label's own line is checked just as closely:
-    // unbalanced parentheses make it no destination at all.
-    let input = "Intro.\n\n<!-- hongdown-disable -->\n\nSee [g].\n\nprose\n[g]: foo(bar\n\n<!-- hongdown-enable -->\n\n[g]: https://example.com/real\n";
+fn test_directive_disable_sees_a_definition_at_a_paragraph_head() {
+    // The parser consumes a definition written at the head of a paragraph but
+    // leaves its line inside the paragraph's span.  Overlooking it would make
+    // the region's duplicate look like the winner and retarget the links.
+    let input = "Intro.\n\n[g]: https://example.com/first\nSome text right after.\n\n<!-- hongdown-disable -->\n\nRaw [g].\n\n[g]: https://example.com/second\n";
+    let result = parse_and_serialize_with_source(input);
+    let winner = result
+        .find("[g]: https://example.com/first")
+        .expect("the winning definition must be kept");
+    let duplicate = result
+        .find("[g]: https://example.com/second")
+        .expect("the region's copy must be preserved");
+    assert!(
+        winner < duplicate,
+        "the winning definition must come first, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_sees_definitions_after_a_multiline_one() {
+    // The first definition takes its destination from the line below it, and
+    // the second sits beneath that.  Overlooking the second would make the
+    // region's duplicate of it the apparent winner and retarget the links.
+    let input = "Intro.\n\n[a]:\n    https://example.com/a\n[b]: https://example.com/b\nSome text right after.\n\n<!-- hongdown-disable -->\n\nRaw [a] and [b].\n\n[b]: https://example.com/wrong\n";
+    let result = parse_and_serialize_with_source(input);
+    let winner = result
+        .find("[b]: https://example.com/b")
+        .expect("the winning definition must be kept");
+    let duplicate = result
+        .find("[b]: https://example.com/wrong")
+        .expect("the region's copy must be preserved");
+    assert!(
+        winner < duplicate,
+        "the winning definition must come first, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_rejects_a_malformed_definition_lookalike() {
+    // Neither line is a definition — the parser leaves both inside a paragraph
+    // — so the real definition must survive.
+    let input = "Intro.\n\n<!-- hongdown-disable -->\n\nSee [g].\n\nprose\n[g]: foo(bar\n[g]: <unterminated\n\n<!-- hongdown-enable -->\n\n[g]: https://example.com/real\n";
     let result = parse_and_serialize_with_source(input);
     assert!(
         result.contains("[g]: https://example.com/real"),
@@ -1501,8 +1561,8 @@ fn test_directive_disable_rejects_a_malformed_same_line_destination() {
 
 #[test]
 fn test_directive_disable_accepts_a_destination_with_balanced_parentheses() {
-    // Balanced parentheses are ordinary in URLs, so the definition is real and
-    // is copied with the region rather than emitted a second time outside it.
+    // Parentheses are ordinary in URLs, so the definition is real and is copied
+    // with the region rather than emitted a second time outside it.
     let input = "Intro.\n\n<!-- hongdown-disable -->\n\nSee [w].\n\n[w]: https://en.wikipedia.org/wiki/Foo_(bar)\n\n<!-- hongdown-enable -->\n\nEnd.\n";
     let result = parse_and_serialize_with_source(input);
     assert_eq!(

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -1907,6 +1907,29 @@ fn test_directive_disable_definition_used_on_both_sides() {
 }
 
 #[test]
+fn test_reference_label_keeps_an_escaped_bracket() {
+    // A label may hold a bracket the backslash escapes.  Cutting the label
+    // there would name a different definition, and the output would no longer
+    // parse as one.
+    let input = "See [x][a\\]b] here.\n\n[a\\]b]: https://example.com/x\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(result, input, "the label must be read whole");
+}
+
+#[test]
+fn test_directive_disable_copy_carries_an_escaped_bracket_label() {
+    // The region carries both the link and its definition, so nothing is left
+    // for the reservation to emit — least of all a definition under a label cut
+    // short at the escaped bracket.
+    let input = "<!-- hongdown-disable -->\n\nSee [x][a\\]b] here.\n\n[a\\]b]: https://example.com/x\n\n<!-- hongdown-enable -->\n\nEnd.\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result, input,
+        "the region must be preserved with nothing added after it"
+    );
+}
+
+#[test]
 fn test_preserve_reference_style_badge() {
     // Reference-style badge links should be preserved as reference style
     let input = "[![JSR][JSR badge]][JSR]\n\n[JSR]: https://jsr.io/@optique\n[JSR badge]: https://jsr.io/badges/@optique/core";

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -1975,6 +1975,108 @@ fn test_directive_disable_sees_a_definition_below_a_three_line_title() {
 }
 
 #[test]
+fn test_directive_disable_sees_a_definition_under_a_list_marker() {
+    // A definition keeps defining a document-wide label wherever it is written,
+    // and a list marker does not make one a task item — the colon rules that
+    // out.  The copy therefore holds the label against a later link.
+    let input = "<!-- hongdown-disable -->\n\n- [foo]: https://example.com/first\n\n<!-- hongdown-enable -->\n\nLater [foo](https://example.com/second).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("Later [foo][foo 2].")
+            && result.contains("[foo 2]: https://example.com/second"),
+        "the later link must keep its own destination, got:\n{}",
+        result
+    );
+    assert_eq!(
+        parse_and_serialize_with_source(&result),
+        result,
+        "formatting must be idempotent"
+    );
+}
+
+#[test]
+fn test_directive_disable_sees_a_definition_with_a_broken_label() {
+    // The label breaks across two lines, which names `foo bar` all the same, so
+    // the copy holds that label too.
+    let input = "<!-- hongdown-disable -->\n\n[foo\nbar]: https://example.com/first\n\n<!-- hongdown-enable -->\n\nLater [foo bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("Later [foo bar][foo bar 2].")
+            && result.contains("[foo bar 2]: https://example.com/second"),
+        "the later link must keep its own destination, got:\n{}",
+        result
+    );
+    assert_eq!(
+        parse_and_serialize_with_source(&result),
+        result,
+        "formatting must be idempotent"
+    );
+}
+
+#[test]
+fn test_directive_disable_sees_a_broken_label_inside_a_blockquote() {
+    // The label breaks across two lines of a blockquote, so both carry its
+    // marker.  A marker is no more part of the label on the second line than on
+    // the first, and the label is `foo bar` either way.
+    let input = "<!-- hongdown-disable -->\n\n> [foo\n> bar]: https://example.com/first\n\n<!-- hongdown-enable -->\n\nLater [foo bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("Later [foo bar][foo bar 2].")
+            && result.contains("[foo bar 2]: https://example.com/second"),
+        "the later link must keep its own destination, got:\n{}",
+        result
+    );
+    assert_eq!(
+        parse_and_serialize_with_source(&result),
+        result,
+        "formatting must be idempotent"
+    );
+}
+
+#[test]
+fn test_directive_disable_sees_a_broken_label_inside_a_list_item() {
+    // A list marks only the line it opens and indents the rest, so the label's
+    // second line carries no marker and reads as part of `foo bar`.
+    let input = "<!-- hongdown-disable -->\n\n- [foo\n  bar]: https://example.com/first\n\n<!-- hongdown-enable -->\n\nLater [foo bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("Later [foo bar][foo bar 2].")
+            && result.contains("[foo bar 2]: https://example.com/second"),
+        "the later link must keep its own destination, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_reads_an_ordered_marker_below_a_label_as_label() {
+    // An ordered marker only opens a block in the middle of one where it
+    // numbers from one, so `2.` goes on reading as part of the label above it.
+    let input = "<!-- hongdown-disable -->\n\n[foo\n2. bar]: https://example.com/first\n\n<!-- hongdown-enable -->\n\nLater [foo 2. bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("Later [foo 2. bar][foo 2. bar 2].")
+            && result.contains("[foo 2. bar 2]: https://example.com/second"),
+        "the copied label must be held, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_list_marker_below_a_label_ends_the_definition() {
+    // A list marker opens a block wherever it stands, so it interrupts rather
+    // than continuing the label above it.  The parser defines nothing here, and
+    // neither does the copy, leaving the label free for the later link.
+    let input = "<!-- hongdown-disable -->\n\n[foo\n- bar]: https://example.com/phantom\n\n<!-- hongdown-enable -->\n\nLater [foo bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("Later [foo bar].")
+            && result.contains("[foo bar]: https://example.com/second"),
+        "the label is free, so the later link keeps it, got:\n{}",
+        result
+    );
+}
+
+#[test]
 fn test_directive_disable_sees_a_definition_below_a_title_of_its_own_line() {
     // The title begins on the line below a complete destination, as CommonMark
     // allows.  The definition beneath it still has to be found.

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -1975,6 +1975,45 @@ fn test_directive_disable_sees_a_definition_below_a_three_line_title() {
 }
 
 #[test]
+fn test_directive_disable_next_line_copies_whole_lines() {
+    // A block's span begins at its content, past the indentation and the
+    // markers of whatever holds it.  Copying from there would lose them, and
+    // with them a definition the parser took out of the list item, which the
+    // span leaves behind — while the lines it sits on count as copied.
+    let input = "<!-- hongdown-disable-next-line -->\n\n  - [a]: https://example.com\n\nSee [x][a 2].\n\n[a 2]: https://example.com\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("  - [a]: https://example.com"),
+        "the copy must keep the whole line, got:\n{}",
+        result
+    );
+    assert_eq!(result, input, "and formatting must be a fixed point");
+}
+
+#[test]
+fn test_directive_disable_next_section_copies_indented_code() {
+    // The indentation is what makes this a code block, and the span reaching
+    // over the blank line below it must not add one to the separator that
+    // follows.
+    let input = "<!-- hongdown-disable-next-section -->\n\n    indented code\n\nAfter.\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(result, input, "the copy must keep the block as it stands");
+}
+
+#[test]
+fn test_directive_disable_next_section_copies_whole_lines() {
+    // Same, for the section-wide skip, where the definition the list item held
+    // is what the copied link resolves through.
+    let input =
+        "<!-- hongdown-disable-next-section -->\n\n[x][a]\n\n  - [a]: https://example.com\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result, input,
+        "the copy must keep the definition the link needs"
+    );
+}
+
+#[test]
 fn test_directive_disable_sees_a_definition_under_a_list_marker() {
     // A definition keeps defining a document-wide label wherever it is written,
     // and a list marker does not make one a task item — the colon rules that

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -1897,6 +1897,16 @@ fn test_directive_disable_preserves_footnote_definition_in_place() {
 }
 
 #[test]
+fn test_directive_disable_file_inside_a_region_reaches_past_it() {
+    // A directive disabling the file does so wherever it is written, so the
+    // region it sits in is not where its effect ends.  What follows the enable
+    // keeps its own marker and spacing.
+    let input = "<!-- hongdown-disable -->\n\n<!-- hongdown-disable-file -->\n\nRaw   text.\n\n<!-- hongdown-enable -->\n\n*   badly    spaced list item\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(result, input, "the rest of the file must be left as it is");
+}
+
+#[test]
 fn test_directive_disable_keeps_trailing_comment_once() {
     // A trailing HTML comment inside the region is part of the verbatim copy
     // and must not be emitted a second time after the references.

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -1917,6 +1917,106 @@ fn test_reference_label_keeps_an_escaped_bracket() {
 }
 
 #[test]
+fn test_directive_disable_reads_a_link_below_a_consumed_definition() {
+    // The copied paragraph opens with a definition, so the parser reports the
+    // link inside it against the paragraph's own start, a line above where it
+    // really sits.  Reading the link there would find no label, the winning
+    // definition would go unreserved, and the copy's own would take over.
+    let input = "[b]: https://example.com/first\n\n<!-- hongdown-disable -->\n\n[b]: https://example.com/second\nRaw [b].\n\n<!-- hongdown-enable -->\n\nEnd.\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result, input,
+        "the winning definition must survive, ahead of the copy"
+    );
+}
+
+#[test]
+fn test_directive_disable_next_line_reads_a_link_below_a_consumed_definition() {
+    // Same block, copied by a different directive: the winning definition still
+    // has to come out above the copy that repeats its label.
+    let input = "[b]: https://example.com/first\n\n<!-- hongdown-disable-next-line -->\n[b]: https://example.com/second\nRaw [b].\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.find("[b]: https://example.com/first")
+            < result.find("[b]: https://example.com/second"),
+        "the winning definition must come first, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_sees_a_definition_below_a_multiline_title() {
+    // The first definition's title runs onto a second line, and the next
+    // definition sits beneath it.  Missing that one would make the region's
+    // copy of its label look like the winner.
+    let input = "[a]: https://example.com/a \"A title\nspanning lines\"\n[b]: https://example.com/first\nSome prose.\n\n<!-- hongdown-disable -->\n\nRaw [b].\n\n[b]: https://example.com/second\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.find("[b]: https://example.com/first")
+            < result.find("[b]: https://example.com/second"),
+        "the winning definition must come first, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_sees_a_definition_below_a_three_line_title() {
+    // The title runs over two continuation lines, and only the delimiter that
+    // opened it closes it.  Stopping at the first continuation would hide the
+    // definition beneath from the scanner.
+    let input = "[a]: https://example.com/a \"A title\nspanning three\nlines\"\n[b]: https://example.com/first\nSome prose.\n\n<!-- hongdown-disable -->\n\nRaw [b].\n\n[b]: https://example.com/second\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.find("[b]: https://example.com/first")
+            < result.find("[b]: https://example.com/second"),
+        "the winning definition must come first, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_sees_a_definition_below_a_title_of_its_own_line() {
+    // The title begins on the line below a complete destination, as CommonMark
+    // allows.  The definition beneath it still has to be found.
+    let input = "[a]: https://example.com/a\n  \"A title\"\n[b]: https://example.com/first\nSome prose.\n\n<!-- hongdown-disable -->\n\nRaw [b].\n\n[b]: https://example.com/second\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.find("[b]: https://example.com/first")
+            < result.find("[b]: https://example.com/second"),
+        "the winning definition must come first, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_sees_a_definition_below_a_title_running_on() {
+    // Same, with the title beginning below the destination and running on to a
+    // further line before it closes.
+    let input = "[a]: https://example.com/a\n  \"A title\nspanning lines\"\n[b]: https://example.com/first\nSome prose.\n\n<!-- hongdown-disable -->\n\nRaw [b].\n\n[b]: https://example.com/second\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.find("[b]: https://example.com/first")
+            < result.find("[b]: https://example.com/second"),
+        "the winning definition must come first, got:\n{}",
+        result
+    );
+}
+
+#[test]
+fn test_directive_disable_title_is_not_closed_by_an_escaped_quote() {
+    // The quotes inside the title are escaped, so they close nothing and the
+    // title still runs to the line below.
+    let input = "[a]: https://example.com/a \"A \\\"quoted\\\" title\nspanning lines\"\n[b]: https://example.com/first\nSome prose.\n\n<!-- hongdown-disable -->\n\nRaw [b].\n\n[b]: https://example.com/second\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.find("[b]: https://example.com/first")
+            < result.find("[b]: https://example.com/second"),
+        "the winning definition must come first, got:\n{}",
+        result
+    );
+}
+
+#[test]
 fn test_directive_disable_copy_carries_an_escaped_bracket_label() {
     // The region carries both the link and its definition, so nothing is left
     // for the reservation to emit — least of all a definition under a label cut

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -1333,6 +1333,47 @@ fn test_directive_disable_without_source_still_skips_formatting() {
 }
 
 #[test]
+fn test_directive_disable_copied_definition_holds_its_label() {
+    // No link resolves through the copied definition, so nothing reveals its
+    // target, but it still defines the label document-wide.  Letting a later
+    // link take that label would put a second definition after it, and since
+    // CommonMark keeps the first, the later link would point at the copy.
+    let input = "<!-- hongdown-disable -->\n\nRaw text.\n\n[guide]: https://example.com/copied\n\n<!-- hongdown-enable -->\n\nLater [guide](https://example.com/other) link.\n";
+    let result = parse_and_serialize_with_source(input);
+    assert_eq!(
+        result,
+        "<!-- hongdown-disable -->\n\nRaw text.\n\n[guide]: https://example.com/copied\n\n<!-- hongdown-enable -->\n\nLater [guide][guide 2] link.\n\n[guide 2]: https://example.com/other\n",
+        "the later link must keep its own destination"
+    );
+    assert_eq!(
+        parse_and_serialize_with_source(&result),
+        result,
+        "formatting must be idempotent"
+    );
+}
+
+#[test]
+fn test_directive_disable_copied_duplicate_holds_its_label() {
+    // The copy repeats a label defined above it, and nothing resolves through
+    // the definition above, so that one is dropped as unused.  The copy is
+    // still a definition, and a later link taking its label would resolve
+    // through the copy rather than through its own destination.
+    let input = "[g]: https://example.com/first\n\n<!-- hongdown-disable -->\n\nRaw text.\n\n[g]: https://example.com/second\n\n<!-- hongdown-enable -->\n\nLater [g](https://example.com/other) link.\n";
+    let result = parse_and_serialize_with_source(input);
+    assert!(
+        result.contains("Later [g][g 2] link.")
+            && result.contains("[g 2]: https://example.com/other"),
+        "the later link must keep its own destination, got:\n{}",
+        result
+    );
+    assert_eq!(
+        parse_and_serialize_with_source(&result),
+        result,
+        "formatting must be idempotent"
+    );
+}
+
+#[test]
 fn test_directive_disable_link_keeps_its_label_against_a_formatted_one() {
     // Both links want the label `guide` for different destinations.  The one
     // inside the region is copied verbatim and cannot be relabelled, so the

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1716,3 +1716,29 @@ fn test_duplicate_link_text_preserves_each_destination() {
         "Distinct reference labels should be idempotent"
     );
 }
+
+#[test]
+fn test_noun_directive_inside_disabled_region_still_applies() {
+    let input = r#"<!-- hongdown-disable -->
+
+<!-- hongdown-proper-nouns: Swift -->
+
+Raw   text.
+
+<!-- hongdown-enable -->
+
+# Using Swift Later
+"#;
+
+    let options = Options {
+        heading_sentence_case: true,
+        ..Options::default()
+    };
+    let result = format(input, &options).unwrap();
+
+    assert!(
+        result.contains("Using Swift later"),
+        "the noun directive must still apply after the region, got:\n{}",
+        result
+    );
+}


### PR DESCRIPTION
Fixes <https://github.com/dahlia/hongdown/issues/27>.

A reference definition is consumed by the parser into a map it does not expose, so it has no node in the tree. A disabled region was emitted by walking its nodes and copying each one's source span, which left nothing to copy a definition from. The definition vanished, the links inside the region pointed at nothing, and since the loss was stable across runs, `--check` never reported the file afterwards.

The issue reports this for `hongdown-disable`. It happens under every disable directive, for a second reason: a link that is copied never registers the definition it uses, so one living outside the region is dropped as unused. The badge in `test_directive_disable_enable` had been losing both its definitions for as long as that test existed, and the test passed because it only asserted that the badge text survived.


Copying the region instead of rebuilding it
-------------------------------------------

The region between the two directives is now taken from the source in one piece, the way `hongdown-disable-file` already took the rest of the file. Its reference definitions survive, and so do its footnote definitions, its indentation and the blank lines inside it. Only the blank lines against the directives themselves are normalized, to one on either side, which is what keeps a second run from adding another.

A footnote definition inside a region used to be relocated and reformatted. Now it stays where it was written, so the pass that collects footnotes has to leave it alone or it would be emitted twice, and a trailing comment inside a region is part of the copy rather than something to move below the definitions.

The blocks that `hongdown-disable-next-line` and `hongdown-disable-next-section` copy one at a time are now copied by their lines too. A block's span begins at its content, past the indentation and the markers of whatever holds it, so copying from there dropped them: an indented code block came out as a paragraph, and a definition the parser had taken out of a list item was dropped from the copy altogether. Both predate this branch.


Who owns a label
----------------

A copied link keeps whatever label the source gave it. A formatted link can be given a derived one, as in `[guide][guide 2]`. So when the two want the same label for different targets, the formatted link is the one that yields, which means the labels copied links use have to be claimed before anything is serialized.

A definition inside a copy holds its label whether or not a link resolves through it. It defines that label document-wide, and CommonMark keeps the first definition of one, so a later link taking it would find its own definition placed after the copy and quietly resolve to the copy's target instead. Its target is unknown in exactly the case where nothing resolves through it, so such a label cannot be shared, only avoided.


When a reserved definition falls due
------------------------------------

Registering a copied link's definition at the moment the copy was emitted let the copy decide where that definition landed, and what it landed among.

Where it landed was wrong because a copied link resolves only once its definition exists. Whether the registration happened at all therefore depended on whether an earlier run had already written it: on the first run the definition was placed by the document's own link, on the second by the copy, and one pass stopped settling the file. A reservation now falls due where the source puts the definition, the way a footnote's references follow their footnote. Since when it is made no longer decides where it lands, the three places that had been arranging this by hand became one pass made up front.


Finding the definitions at all
------------------------------

Comrak keeps its reference map private, so the definitions have to be recognized from the source. What makes that reliable is block context taken from the tree: the lines a leaf block occupies are excluded, container blocks are descended into so that the gaps between their children stay visible, and a line the parser kept out of every leaf block while looking like a definition is one. Prose that merely resembles a definition is part of its block and never reaches the test. This replaced a pile of heuristics about destinations and containers that kept getting the boundary cases wrong.

A paragraph complicates it by keeping the lines of a definition consumed at its head. Those lines have to stay visible to the scanner while the paragraph's own lines do not, so where the content starts is read two ways, by the line breaks the paragraph contains and by the definitions its head is made of, and a line is left visible only where both agree. Each reading misjudges what the other catches: a code span holding a newline for the first, an opening line that merely resembles a definition for the second. Comrak also reports an inline inside such a paragraph above its real line, by the height of the consumed head, so the reads that recover a copied link's label carry that offset.

Reading a definition is one function rather than two. It follows every part that may break across lines, and it treats container markers the way the parser does: a list marker before a definition is set aside, since `- [x]: done` is no task item, while below one a bullet opens an item and ends the definition, as does an ordered marker numbering from one. An ordered marker numbering from anywhere else goes on reading as part of the line above it.


Cost
----

The expensive half of that analysis, which is the definition scan and the walks that claim and reserve labels, runs only where a document has copied something. Membership of the copied lines is a line-indexed table rather than a list of spans to walk, because scanning a span per line cost time quadratic in the number of blocks. Locally, 64000 copied blocks went from 68 seconds to about 0.15, and a document with no directives at all is where it was at the branch point, around 0.12 seconds for 48000 blocks.


What this leaves alone
----------------------

Three defects turned up while testing that predate this branch and belong to the earlier reference work rather than to disabled regions. Two are filed: a definition sinking to a footnote's section when they share a label, https://github.com/dahlia/hongdown/issues/30, and labels differing only by non-ASCII edge whitespace being merged, https://github.com/dahlia/hongdown/issues/31. The third has no issue yet. Allocating a numbered label does not check whether that label already appears as unresolved reference syntax, so formatting can turn literal text like `See [guide 2].` into a link. This branch makes that one reachable in one more way, since a copied definition can push a formatted link into a numbered label, though the flaw is in the allocator.

Two repairs did land here that are not about disabled regions, because the code they were in is what produced the wrong answers above. A reference label holding a bracket escaped with a backslash, as in `[a\]b]`, was cut short at that bracket, which lost the link and left the definition unreadable on the next run. And `ensure_blank_line` no longer writes a separator into empty output, so a document whose first emitted thing is a definition does not start with blank lines.


Testing
-------

The branch adds 58 tests, many of which format twice and compare, since most of what went wrong here showed up as a file that `--write` wrote and `--check` then rejected. `cargo test` reports 775 unit tests and 79 integration tests. Running Hongdown over the repository's own Markdown produces no changes.
