### PR TITLE
Prevent numbered labels from resolving ordinary text

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,11 @@ To be released.
     otherwise the colliding link gets a numbered label and full reference
     syntax, as in `[guide][guide 2]`.  [[#26], [#29]]
 
+ -  Fixed a bug where a numbered label assigned to a colliding link could match
+    unresolved reference syntax elsewhere in the document, silently turning
+    ordinary bracketed text into a link.  Numbered label allocation now skips
+    labels already used by unresolved references.  [[#33], [#34]]
+
  -  Fixed a bug where a reference definition needed by a later section was
     dropped entirely when an earlier section had already defined the same
     label with a different destination, leaving the later link pointing at
@@ -76,6 +81,8 @@ To be released.
 [#27]: https://github.com/dahlia/hongdown/issues/27
 [#29]: https://github.com/dahlia/hongdown/pull/29
 [#32]: https://github.com/dahlia/hongdown/pull/32
+[#33]: https://github.com/dahlia/hongdown/issues/33
+[#34]: https://github.com/dahlia/hongdown/pull/34
 
 
 Version 0.5.1

--- a/STYLE.md
+++ b/STYLE.md
@@ -431,6 +431,10 @@ collapsed and Unicode case folding applied.  So `[Guide]` and `[guide]` are
 the same label, as are `[Straße]` and `[STRASSE]`, and one of them is
 renumbered unless both point at the same target.
 
+For numbered label allocation, a label appearing as unresolved reference
+syntax is also considered occupied.  Allocation skips it rather than adding a
+definition that would silently turn the bracketed text into a link.
+
 *Rationale*: A reference definition is document-wide, and a duplicate
 definition is ignored by the parser rather than merged.  Sharing a label
 between different targets would therefore silently change where one of the

--- a/packages/wasm/test/index.test.ts
+++ b/packages/wasm/test/index.test.ts
@@ -247,6 +247,22 @@ describe("formatWithCodeFormatter", () => {
     assert.ok(output.startsWith("# Test"), "H1 should be ATX style");
     assert.ok(output.includes("CODE"), "Code should be transformed");
   });
+
+  it("reserves restored MDX labels", async () => {
+    const input =
+      "See [foo {bar} 2].\n\n" +
+      " -  Read [foo {bar}](https://example.com/first).\n" +
+      " -  Read [foo {bar}](https://example.com/second).\n";
+    const { output, warnings } = await formatWithCodeFormatter(input, {
+      mdx: true,
+    });
+    assert.ok(output.includes("[foo {bar}][foo {bar} 3]"));
+    assert.equal(warnings.length, 1);
+    assert.equal(
+      warnings[0].message,
+      "undefined reference link: [foo {bar} 2]",
+    );
+  });
 });
 
 describe("options", () => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,18 @@ pub use serializer::punctuation::{PunctuationError, validate_dash_settings};
 
 use comrak::{Arena, Options as ComrakOptions, parse_document};
 
+pub(crate) fn comrak_options(options: &Options) -> ComrakOptions<'static> {
+    let mut comrak_options = ComrakOptions::default();
+    comrak_options.extension.front_matter_delimiter = Some("---".to_string());
+    comrak_options.extension.table = true;
+    comrak_options.extension.description_lists = true;
+    comrak_options.extension.alerts = true;
+    comrak_options.extension.footnotes = true;
+    comrak_options.extension.tasklist = true;
+    comrak_options.extension.math_dollars = options.math;
+    comrak_options
+}
+
 /// External code formatter configuration.
 #[derive(Debug, Clone)]
 pub struct CodeFormatter {
@@ -253,21 +265,20 @@ pub fn format(input: &str, options: &Options) -> Result<String, FormatError> {
         return Ok(String::new());
     }
 
-    let mut comrak_options = ComrakOptions::default();
-    comrak_options.extension.front_matter_delimiter = Some("---".to_string());
-    comrak_options.extension.table = true;
-    comrak_options.extension.description_lists = true;
-    comrak_options.extension.alerts = true;
-    comrak_options.extension.footnotes = true;
-    comrak_options.extension.tasklist = true;
-    comrak_options.extension.math_dollars = options.math;
+    let comrak_options = comrak_options(options);
 
     if options.mdx
         && let Some(protection) = mdx::protect(input, &comrak_options)
     {
         let arena = Arena::new();
         let root = parse_document(&arena, &protection.source, &comrak_options);
-        let output = serializer::serialize_with_source(root, options, Some(&protection.source));
+        let output = serializer::serialize_with_source_and_warnings_and_replacements(
+            root,
+            options,
+            Some(&protection.source),
+            protection.reference_label_replacements(),
+        )
+        .output;
         return Ok(protection.restore(&output));
     }
 
@@ -308,26 +319,24 @@ pub fn format_with_warnings(input: &str, options: &Options) -> Result<FormatResu
         });
     }
 
-    let mut comrak_options = ComrakOptions::default();
-    comrak_options.extension.front_matter_delimiter = Some("---".to_string());
-    comrak_options.extension.table = true;
-    comrak_options.extension.description_lists = true;
-    comrak_options.extension.alerts = true;
-    comrak_options.extension.footnotes = true;
-    comrak_options.extension.tasklist = true;
-    comrak_options.extension.math_dollars = options.math;
+    let comrak_options = comrak_options(options);
 
     if options.mdx
         && let Some(protection) = mdx::protect(input, &comrak_options)
     {
         let arena = Arena::new();
         let root = parse_document(&arena, &protection.source, &comrak_options);
-        let mut result =
-            serializer::serialize_with_source_and_warnings(root, options, Some(&protection.source));
+        let mut result = serializer::serialize_with_source_and_warnings_and_replacements(
+            root,
+            options,
+            Some(&protection.source),
+            protection.reference_label_replacements(),
+        );
         // Warning line numbers refer to the protected source; map them back to
         // the original so multi-line constructs do not shift them.
         for warning in &mut result.warnings {
             warning.line = protection.original_line(warning.line);
+            warning.message = protection.restore(&warning.message);
         }
         return Ok(FormatResult {
             output: protection.restore(&result.output),

--- a/src/mdx.rs
+++ b/src/mdx.rs
@@ -55,6 +55,13 @@ impl Protection {
         result
     }
 
+    pub(crate) fn reference_label_replacements(&self) -> Vec<(String, String)> {
+        self.replacements
+            .iter()
+            .map(|protected| (protected.token.clone(), protected.original.clone()))
+            .collect()
+    }
+
     /// Map a 1-indexed line number in the protected source back to the original
     /// source.
     ///

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -1729,7 +1729,7 @@ impl<'a> Serializer<'a> {
             if let Some(caps) = abbr_pattern.captures(line)
                 && let Some(abbr) = caps.get(1)
             {
-                abbreviations.insert(normalize_reference_key(abbr.as_str()));
+                abbreviations.insert(abbr.as_str().to_string());
             }
         }
 
@@ -2280,7 +2280,7 @@ impl<'a> Serializer<'a> {
             let line = Self::inline_source_line(inline, start);
             let raw_key = normalize_reference_key(raw_label);
             let warning_exempt =
-                abbreviations.contains(&raw_key) || source_ref_defs.contains(&raw_key);
+                abbreviations.contains(raw_label) || source_ref_defs.contains(&raw_key);
             let verbatim =
                 warning_exempt && self.is_verbatim_reference_definition(inline, start, match_end);
             references.push((

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -2462,90 +2462,33 @@ impl<'a> Serializer<'a> {
         resolved_reference_definitions: &str,
         labels: &[(usize, usize)],
     ) -> Vec<String> {
-        if labels.is_empty() {
-            return Vec::new();
-        }
-        let render_fallback = || {
-            labels
-                .iter()
-                .map(|&(start, end)| {
-                    inline_source
-                        .get(start..end)
-                        .map_or_else(String::new, |label| {
-                            self.render_unresolved_reference_label(label)
-                        })
-                })
-                .collect()
-        };
-        let (open_marker, close_marker) = Self::unused_reference_label_markers(inline_source);
-        let marker_capacity = labels.len() * (open_marker.len() + close_marker.len());
-        let mut marked_source = String::with_capacity(inline_source.len() + marker_capacity);
-        let mut source_offset = 0;
-        for &(label_start, label_end) in labels {
-            let Some(marker_start) = label_start.checked_sub(1) else {
-                return render_fallback();
-            };
-            let Some(marker_end) = label_end.checked_add(1) else {
-                return render_fallback();
-            };
-            if marker_start < source_offset
-                || label_end < label_start
-                || marker_end > inline_source.len()
-            {
-                return render_fallback();
-            }
-            marked_source.push_str(&inline_source[source_offset..marker_start]);
-            marked_source.push_str(&open_marker);
-            marked_source.push_str(&inline_source[marker_start..marker_end]);
-            marked_source.push_str(&close_marker);
-            source_offset = marker_end;
-        }
-        marked_source.push_str(&inline_source[source_offset..]);
-        marked_source.retain(|character| character != '\0');
+        self.render_marked_reference_labels(
+            inline_source,
+            labels,
+            |marked_source| {
+                let source = if resolved_reference_definitions.is_empty() {
+                    marked_source
+                } else {
+                    format!("{marked_source}\n\n{resolved_reference_definitions}")
+                };
+                let arena = Arena::new();
+                let options = crate::comrak_options(self.options);
+                let root = parse_document(&arena, &source, &options);
+                let paragraph = root
+                    .children()
+                    .find(|child| matches!(&child.data.borrow().value, NodeValue::Paragraph))?;
 
-        let source = if resolved_reference_definitions.is_empty() {
-            marked_source
-        } else {
-            format!("{marked_source}\n\n{resolved_reference_definitions}")
-        };
-        let arena = Arena::new();
-        let options = crate::comrak_options(self.options);
-        let root = parse_document(&arena, &source, &options);
-        let Some(paragraph) = root
-            .children()
-            .find(|child| matches!(&child.data.borrow().value, NodeValue::Paragraph))
-        else {
-            return render_fallback();
-        };
-
-        let source_lines = source.lines().collect();
-        let mut serializer = Serializer::new(self.options, source_lines, false);
-        let mut rendered = String::new();
-        serializer.collect_inline_content(paragraph, &mut rendered);
-        rendered.retain(|character| {
-            character != super::MATH_TOKEN_OPEN && character != super::MATH_TOKEN_CLOSE
-        });
-
-        let mut rendered_labels = Vec::with_capacity(labels.len());
-        let mut rendered_offset = 0;
-        for _ in labels {
-            let Some(open) = rendered[rendered_offset..].find(&open_marker) else {
-                return render_fallback();
-            };
-            let marked_start = rendered_offset + open + open_marker.len();
-            let Some(close) = rendered[marked_start..].find(&close_marker) else {
-                return render_fallback();
-            };
-            let marked_end = marked_start + close;
-            let Some(label) =
-                Self::strip_rendered_reference_brackets(&rendered[marked_start..marked_end])
-            else {
-                return render_fallback();
-            };
-            rendered_labels.push(label.replace(['\0', '\n'], " "));
-            rendered_offset = marked_end + close_marker.len();
-        }
-        rendered_labels
+                let source_lines = source.lines().collect();
+                let mut serializer = Serializer::new(self.options, source_lines, false);
+                let mut rendered = String::new();
+                serializer.collect_inline_content(paragraph, &mut rendered);
+                rendered.retain(|character| {
+                    character != super::MATH_TOKEN_OPEN && character != super::MATH_TOKEN_CLOSE
+                });
+                Some(rendered)
+            },
+            |label| label.replace(['\0', '\n'], " "),
+        )
     }
 
     /// Render an unresolved label in the context of its complete heading.
@@ -2561,23 +2504,72 @@ impl<'a> Serializer<'a> {
         if labels.is_empty() {
             return Vec::new();
         }
+        #[cfg(test)]
+        HEADING_REFERENCE_RENDER_PASSES.with(|passes| passes.set(passes.get() + 1));
+        self.render_marked_reference_labels(
+            heading_source,
+            labels,
+            |marked_source| {
+                let source = if resolved_reference_definitions.is_empty() {
+                    format!("# {marked_source}")
+                } else {
+                    format!("# {marked_source}\n\n{resolved_reference_definitions}")
+                };
+                let arena = Arena::new();
+                let options = crate::comrak_options(self.options);
+                let root = parse_document(&arena, &source, &options);
+                let heading = root
+                    .children()
+                    .find(|child| matches!(&child.data.borrow().value, NodeValue::Heading(_)))?;
+
+                let source_lines = source.lines().collect();
+                let mut serializer = Serializer::new(self.options, source_lines, false);
+                let heading_text = serializer.collect_text(heading);
+                let (heading_body, _) =
+                    super::heading::split_trailing_explicit_anchor(&heading_text);
+                if self.options.heading_sentence_case {
+                    let mut proper_nouns = self.options.heading_proper_nouns.clone();
+                    proper_nouns.extend(self.directive_proper_nouns.clone());
+                    let mut common_nouns = self.options.heading_common_nouns.clone();
+                    common_nouns.extend(self.directive_common_nouns.clone());
+                    Some(super::heading::to_sentence_case(
+                        heading_body,
+                        &proper_nouns,
+                        &common_nouns,
+                    ))
+                } else {
+                    Some(heading_body.to_string())
+                }
+            },
+            str::to_string,
+        )
+    }
+
+    /// Mark reference labels, render their source in context, and extract the
+    /// rendered spellings between the markers.
+    fn render_marked_reference_labels(
+        &self,
+        source: &str,
+        labels: &[(usize, usize)],
+        render_marked_source: impl FnOnce(String) -> Option<String>,
+        normalize_label: impl Fn(&str) -> String,
+    ) -> Vec<String> {
+        if labels.is_empty() {
+            return Vec::new();
+        }
         let render_fallback = || {
             labels
                 .iter()
                 .map(|&(start, end)| {
-                    heading_source
-                        .get(start..end)
-                        .map_or_else(String::new, |label| {
-                            self.render_unresolved_reference_label(label)
-                        })
+                    source.get(start..end).map_or_else(String::new, |label| {
+                        self.render_unresolved_reference_label(label)
+                    })
                 })
                 .collect()
         };
-        #[cfg(test)]
-        HEADING_REFERENCE_RENDER_PASSES.with(|passes| passes.set(passes.get() + 1));
-        let (open_marker, close_marker) = Self::unused_reference_label_markers(heading_source);
+        let (open_marker, close_marker) = Self::unused_reference_label_markers(source);
         let marker_capacity = labels.len() * (open_marker.len() + close_marker.len());
-        let mut marked_source = String::with_capacity(heading_source.len() + marker_capacity);
+        let mut marked_source = String::with_capacity(source.len() + marker_capacity);
         let mut source_offset = 0;
         for &(label_start, label_end) in labels {
             let Some(marker_start) = label_start.checked_sub(1) else {
@@ -2586,50 +2578,22 @@ impl<'a> Serializer<'a> {
             let Some(marker_end) = label_end.checked_add(1) else {
                 return render_fallback();
             };
-            if marker_start < source_offset
-                || label_end < label_start
-                || marker_end > heading_source.len()
+            if marker_start < source_offset || label_end < label_start || marker_end > source.len()
             {
                 return render_fallback();
             }
-            marked_source.push_str(&heading_source[source_offset..marker_start]);
+            marked_source.push_str(&source[source_offset..marker_start]);
             marked_source.push_str(&open_marker);
-            marked_source.push_str(&heading_source[marker_start..marker_end]);
+            marked_source.push_str(&source[marker_start..marker_end]);
             marked_source.push_str(&close_marker);
             source_offset = marker_end;
         }
-        marked_source.push_str(&heading_source[source_offset..]);
+        marked_source.push_str(&source[source_offset..]);
         marked_source.retain(|character| character != '\0');
 
-        let source = if resolved_reference_definitions.is_empty() {
-            format!("# {marked_source}")
-        } else {
-            format!("# {marked_source}\n\n{resolved_reference_definitions}")
-        };
-        let arena = Arena::new();
-        let options = crate::comrak_options(self.options);
-        let root = parse_document(&arena, &source, &options);
-        let Some(heading) = root
-            .children()
-            .find(|child| matches!(&child.data.borrow().value, NodeValue::Heading(_)))
-        else {
+        let Some(rendered) = render_marked_source(marked_source) else {
             return render_fallback();
         };
-
-        let source_lines = source.lines().collect();
-        let mut serializer = Serializer::new(self.options, source_lines, false);
-        let heading_text = serializer.collect_text(heading);
-        let (heading_body, _) = super::heading::split_trailing_explicit_anchor(&heading_text);
-        let rendered = if self.options.heading_sentence_case {
-            let mut proper_nouns = self.options.heading_proper_nouns.clone();
-            proper_nouns.extend(self.directive_proper_nouns.clone());
-            let mut common_nouns = self.options.heading_common_nouns.clone();
-            common_nouns.extend(self.directive_common_nouns.clone());
-            super::heading::to_sentence_case(heading_body, &proper_nouns, &common_nouns)
-        } else {
-            heading_body.to_string()
-        };
-
         let mut rendered_labels = Vec::with_capacity(labels.len());
         let mut rendered_offset = 0;
         for _ in labels {
@@ -2646,7 +2610,7 @@ impl<'a> Serializer<'a> {
             else {
                 return render_fallback();
             };
-            rendered_labels.push(label.to_string());
+            rendered_labels.push(normalize_label(label));
             rendered_offset = marked_end + close_marker.len();
         }
         rendered_labels
@@ -2670,6 +2634,19 @@ impl<'a> Serializer<'a> {
         const BMP_COUNT: usize = (BMP_END - BMP_START + 1) as usize;
         const PLANE_COUNT: usize = (PLANE_15_END - PLANE_15_START + 1) as usize;
         const PRIVATE_USE_COUNT: usize = BMP_COUNT + PLANE_COUNT * 2;
+
+        let contains_private_use = source.chars().any(|character| {
+            matches!(
+                character as u32,
+                BMP_START..=BMP_END | PLANE_15_START..=PLANE_15_END | PLANE_16_START..=PLANE_16_END
+            )
+        });
+        if !contains_private_use {
+            return (
+                char::from_u32(BMP_START).unwrap().to_string(),
+                char::from_u32(BMP_START + 1).unwrap().to_string(),
+            );
+        }
 
         let private_use_index = |character: char| {
             let value = character as u32;

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -45,6 +45,13 @@ struct VerbatimReference {
     line: usize,
 }
 
+struct DisableRegionBounds {
+    region_start: usize,
+    region_end: usize,
+    enable_index: Option<usize>,
+    disables_file: bool,
+}
+
 struct UnresolvedReferenceInline {
     text: String,
     opener_ranges: Vec<(usize, usize)>,
@@ -239,26 +246,10 @@ impl<'a> Serializer<'a> {
                         // consumed by the parser and has no node of its own, so
                         // a node-by-node copy would leave the region's links
                         // pointing at nothing.
-                        let enable_index = Self::find_enable_directive(&children, i);
-                        let region_last = enable_index.unwrap_or(children.len());
-                        let region_start = child.data.borrow().sourcepos.end.line + 1;
-                        // A directive disabling the file, written inside the
-                        // region, disables it past the region's own end, so the
-                        // copy runs to the last line and nothing follows it.
-                        let disables_file = Self::disables_file(&children[i + 1..region_last]);
-                        let region_end = match enable_index {
-                            Some(_) if disables_file => self.source_lines.len(),
-                            Some(j) => children[j]
-                                .data
-                                .borrow()
-                                .sourcepos
-                                .start
-                                .line
-                                .saturating_sub(1),
-                            None => self.source_lines.len(),
-                        };
+                        let bounds = self.disable_region_bounds(&children, i);
+                        let region_last = bounds.enable_index.unwrap_or(children.len());
                         let region = self
-                            .extract_source_lines(region_start, region_end)
+                            .extract_source_lines(bounds.region_start, bounds.region_end)
                             .map(|source| Self::trim_blank_lines(&source))
                             .unwrap_or_default();
 
@@ -294,7 +285,7 @@ impl<'a> Serializer<'a> {
                             self.output.push('\n');
                             self.output.push_str(&region);
                             self.output.push('\n');
-                            if disables_file {
+                            if bounds.disables_file {
                                 return;
                             }
                             skip_until = region_last;
@@ -475,6 +466,34 @@ impl<'a> Serializer<'a> {
             .map(|(i, _)| i)
     }
 
+    /// Find the source bounds and closing directive of a disabled region.
+    fn disable_region_bounds<'b>(
+        &self,
+        children: &[&'b AstNode<'b>],
+        from: usize,
+    ) -> DisableRegionBounds {
+        let enable_index = Self::find_enable_directive(children, from);
+        let region_last = enable_index.unwrap_or(children.len());
+        let disables_file = Self::disables_file(&children[from + 1..region_last]);
+        let region_end = match enable_index {
+            Some(_) if disables_file => self.source_lines.len(),
+            Some(index) => children[index]
+                .data
+                .borrow()
+                .sourcepos
+                .start
+                .line
+                .saturating_sub(1),
+            None => self.source_lines.len(),
+        };
+        DisableRegionBounds {
+            region_start: children[from].data.borrow().sourcepos.end.line + 1,
+            region_end,
+            enable_index,
+            disables_file,
+        }
+    }
+
     /// Collect the source line ranges that are copied verbatim instead of being
     /// rebuilt from the AST: every `hongdown-disable` region and the tail that
     /// follows a `hongdown-disable-file` directive.
@@ -498,28 +517,13 @@ impl<'a> Serializer<'a> {
                     break;
                 }
                 Some(Directive::Disable) => {
-                    let enable_index = Self::find_enable_directive(children, i);
-                    let region_last = enable_index.unwrap_or(children.len());
-                    // A directive disabling the file leaves everything after it
-                    // as it stands, which reaches past the end of the region it
-                    // is written in.
-                    if Self::disables_file(&children[i + 1..region_last]) {
-                        ranges.push((start_line, last_line));
+                    let bounds = self.disable_region_bounds(children, i);
+                    ranges.push((bounds.region_start, bounds.region_end));
+                    if bounds.disables_file {
                         break;
                     }
-                    let end_line = match enable_index {
-                        Some(j) => children[j]
-                            .data
-                            .borrow()
-                            .sourcepos
-                            .start
-                            .line
-                            .saturating_sub(1),
-                        None => last_line,
-                    };
-                    ranges.push((start_line, end_line));
                     // Nested directives inside the region are part of the copy.
-                    i = region_last;
+                    i = bounds.enable_index.unwrap_or(children.len());
                 }
                 _ => {}
             }
@@ -850,10 +854,10 @@ impl<'a> Serializer<'a> {
     /// Mark every line of the given ranges in a line-indexed table.
     fn mark_lines(ranges: &[(usize, usize)], lines: &mut [bool]) {
         for (start, end) in ranges {
-            for line in (*start).max(1)..=*end {
-                if let Some(marked) = lines.get_mut(line - 1) {
-                    *marked = true;
-                }
+            let start = (*start).max(1);
+            let end = (*end).min(lines.len());
+            for line in start..=end {
+                lines[line - 1] = true;
             }
         }
     }

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -3,6 +3,7 @@
 use std::sync::LazyLock;
 
 use comrak::nodes::{AstNode, NodeValue};
+use comrak::{Arena, parse_document};
 use regex::Regex;
 use unicode_width::UnicodeWidthStr;
 
@@ -44,6 +45,33 @@ struct VerbatimReference {
     line: usize,
 }
 
+struct UnresolvedReferenceInline {
+    text: String,
+    opener_ranges: Vec<(usize, usize)>,
+    opaque_ranges: Vec<(usize, usize)>,
+    heading_removed_ranges: Vec<(usize, usize)>,
+    heading: bool,
+    start_line: usize,
+    line_columns: Vec<usize>,
+    line_offsets: Vec<usize>,
+}
+
+struct UndefinedReference {
+    line: usize,
+    label: String,
+    warning_exempt: bool,
+}
+
+#[cfg(test)]
+std::thread_local! {
+    static HEADING_REFERENCE_RENDER_PASSES: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+    static UNRESOLVED_SOURCE_INDEX_ENTRIES: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+    static SOURCE_EXCLUSION_RANGE_SCANS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
 impl<'a> Serializer<'a> {
     pub(super) fn serialize_document<'b>(&mut self, node: &'b AstNode<'b>) {
         let children: Vec<_> = node.children().collect();
@@ -69,7 +97,7 @@ impl<'a> Serializer<'a> {
             let mut in_leaf_block = vec![false; self.source_lines.len()];
             Self::mark_leaf_block_lines(node, &self.source_lines, &mut in_leaf_block);
             for (label, lines) in
-                Self::collect_reference_definition_lines(&self.source_lines, &in_leaf_block)
+                self.collect_reference_definition_lines(&self.source_lines, &in_leaf_block)
             {
                 // Only the first definition of a label counts, the way
                 // CommonMark resolves it.  When it is the one the copy carries,
@@ -911,6 +939,7 @@ impl<'a> Serializer<'a> {
     /// definition, in a paragraph, a code block, raw HTML or a heading, is part
     /// of its block and never reaches this test.
     fn collect_reference_definition_lines(
+        &self,
         source_lines: &[&str],
         in_leaf_block: &[bool],
     ) -> std::collections::HashMap<String, Vec<usize>> {
@@ -942,7 +971,7 @@ impl<'a> Serializer<'a> {
                 Some((label, next)) => {
                     if !label.starts_with('^') {
                         definitions
-                            .entry(normalize_reference_key(&label))
+                            .entry(self.reference_key(&label))
                             .or_default()
                             .push(line_number);
                     }
@@ -988,7 +1017,7 @@ impl<'a> Serializer<'a> {
             && let Some(label) = self.verbatim_reference_label(node, line_offset)
         {
             self.verbatim_reference_claims
-                .entry(normalize_reference_key(&label))
+                .entry(self.reference_key(&label))
                 .or_insert(ReferenceLink { label, url, title });
         }
     }
@@ -1058,7 +1087,7 @@ impl<'a> Serializer<'a> {
     ) {
         for reference in references {
             // A definition inside a verbatim range travels with its own copy.
-            let key = normalize_reference_key(&reference.label);
+            let key = self.reference_key(&reference.label);
             if self.verbatim_reference_labels.contains(&key) {
                 continue;
             }
@@ -1531,25 +1560,41 @@ impl<'a> Serializer<'a> {
             return;
         }
 
+        let opaque_block_ranges = Self::collect_opaque_block_line_ranges(node);
+        let mut opaque_block_lines = vec![false; self.source_lines.len()];
+        Self::mark_lines(&opaque_block_ranges, &mut opaque_block_lines);
+
         // Collect PHP Markdown Extra abbreviation definitions from source
-        let abbreviations = Self::collect_abbreviations(&self.source_lines);
+        let abbreviations = Self::collect_abbreviations(&self.source_lines, &opaque_block_lines);
 
         // Collect reference definitions from source that comrak may not have parsed
         // (e.g., when they follow abbreviation definitions without a blank line)
-        let source_ref_defs = Self::collect_source_reference_definitions(&self.source_lines);
+        let source_ref_defs =
+            Self::collect_source_reference_definitions(&self.source_lines, &opaque_block_lines);
 
-        // Collect warnings first to avoid borrow issues
-        let warnings = Self::find_undefined_references_in_ast(
+        // Collect undefined references first to avoid borrow issues.
+        let undefined_references = self.find_undefined_references_in_ast(
             node,
-            &self.source_lines,
             &abbreviations,
             &source_ref_defs,
+            disabled_ranges,
         );
 
-        // Filter out warnings that fall within disabled regions
-        for (line, msg) in warnings {
-            if !Self::is_line_in_ranges(line, disabled_ranges) {
-                self.add_warning(line, msg);
+        for reference in undefined_references {
+            let label = self.restore_reference_label(&reference.label);
+            // The label remains occupied even where the warning is suppressed:
+            // defining it would still turn copied bracketed text into a link.
+            self.unresolved_reference_labels
+                .insert(self.reference_key(&label));
+
+            // Filter out warnings that fall within disabled regions.
+            if !reference.warning_exempt
+                && !Self::is_line_in_ranges(reference.line, disabled_ranges)
+            {
+                self.add_warning(
+                    reference.line,
+                    format!("undefined reference link: [{}]", label),
+                );
             }
         }
     }
@@ -1635,22 +1680,52 @@ impl<'a> Serializer<'a> {
 
     /// Check if a line number falls within any of the given inclusive ranges.
     fn is_line_in_ranges(line: usize, ranges: &[(usize, usize)]) -> bool {
+        ranges.iter().any(|(start, end)| {
+            #[cfg(test)]
+            SOURCE_EXCLUSION_RANGE_SCANS.with(|scans| scans.set(scans.get() + 1));
+            line >= *start && line <= *end
+        })
+    }
+
+    /// Collect source lines whose contents cannot define Markdown references.
+    fn collect_opaque_block_line_ranges<'b>(node: &'b AstNode<'b>) -> Vec<(usize, usize)> {
+        fn walk<'b>(node: &'b AstNode<'b>, ranges: &mut Vec<(usize, usize)>) {
+            let data = node.data.borrow();
+            if matches!(
+                &data.value,
+                NodeValue::CodeBlock(_) | NodeValue::HtmlBlock(_) | NodeValue::FrontMatter(_)
+            ) {
+                ranges.push((data.sourcepos.start.line, data.sourcepos.end.line));
+                return;
+            }
+            drop(data);
+            for child in node.children() {
+                walk(child, ranges);
+            }
+        }
+
+        let mut ranges = Vec::new();
+        walk(node, &mut ranges);
         ranges
-            .iter()
-            .any(|(start, end)| line >= *start && line <= *end)
     }
 
     /// Collect PHP Markdown Extra abbreviation definitions from source.
     /// Returns a set of abbreviation names (e.g., "HTML" from "*[HTML]: Hyper Text Markup Language").
-    fn collect_abbreviations(source_lines: &[&str]) -> std::collections::HashSet<String> {
+    fn collect_abbreviations(
+        source_lines: &[&str],
+        excluded_lines: &[bool],
+    ) -> std::collections::HashSet<String> {
         let mut abbreviations = std::collections::HashSet::new();
         let abbr_pattern = Regex::new(r"^\*\[([^\]]+)\]:").unwrap();
 
-        for line in source_lines {
+        for (index, line) in source_lines.iter().enumerate() {
+            if excluded_lines.get(index).copied().unwrap_or(false) {
+                continue;
+            }
             if let Some(caps) = abbr_pattern.captures(line)
                 && let Some(abbr) = caps.get(1)
             {
-                abbreviations.insert(abbr.as_str().to_string());
+                abbreviations.insert(normalize_reference_key(abbr.as_str()));
             }
         }
 
@@ -1663,16 +1738,20 @@ impl<'a> Serializer<'a> {
     /// Returns a set of (label, line_number) tuples.
     fn collect_source_reference_definitions(
         source_lines: &[&str],
+        excluded_lines: &[bool],
     ) -> std::collections::HashSet<String> {
         let mut definitions = std::collections::HashSet::new();
         // Pattern: [label]: URL at start of line (with optional leading whitespace)
         let ref_def_pattern = Regex::new(r"^\s*\[([^\]]+)\]:\s*\S").unwrap();
 
-        for line in source_lines {
+        for (index, line) in source_lines.iter().enumerate() {
+            if excluded_lines.get(index).copied().unwrap_or(false) {
+                continue;
+            }
             if let Some(caps) = ref_def_pattern.captures(line)
                 && let Some(label) = caps.get(1)
             {
-                definitions.insert(label.as_str().to_string());
+                definitions.insert(normalize_reference_key(label.as_str()));
             }
         }
 
@@ -1680,145 +1759,971 @@ impl<'a> Serializer<'a> {
     }
 
     /// Find undefined references by walking the AST.
-    /// Returns a vector of (line_number, warning_message) tuples.
+    /// Returns a vector of (line_number, label) tuples.
     fn find_undefined_references_in_ast<'b>(
+        &mut self,
         node: &'b AstNode<'b>,
-        source_lines: &[&str],
         abbreviations: &std::collections::HashSet<String>,
         source_ref_defs: &std::collections::HashSet<String>,
-    ) -> Vec<(usize, String)> {
-        let mut warnings = Vec::new();
+        disabled_ranges: &[(usize, usize)],
+    ) -> Vec<UndefinedReference> {
+        let mut undefined_references = Vec::new();
 
-        // Pattern to find [label] or [text][label] in text nodes
-        // This matches text that looks like a reference link but wasn't parsed as one
-        // The pattern [^\[\]] ensures the label doesn't start with [ or ]
-        let ref_pattern = Regex::new(r"\[([^\[\]][^\]]*)\](?:\[([^\]]*)\])?").unwrap();
-
-        Self::walk_ast_for_undefined_refs(
+        self.walk_ast_for_undefined_refs(
             node,
-            source_lines,
-            &ref_pattern,
             abbreviations,
             source_ref_defs,
-            &mut warnings,
+            disabled_ranges,
+            &mut undefined_references,
+            0,
         );
 
-        warnings
+        undefined_references
     }
 
     /// Recursively walk the AST looking for undefined references in Text nodes.
     fn walk_ast_for_undefined_refs<'b>(
+        &mut self,
         node: &'b AstNode<'b>,
-        source_lines: &[&str],
-        ref_pattern: &Regex,
         abbreviations: &std::collections::HashSet<String>,
         source_ref_defs: &std::collections::HashSet<String>,
-        warnings: &mut Vec<(usize, String)>,
+        disabled_ranges: &[(usize, usize)],
+        undefined_references: &mut Vec<UndefinedReference>,
+        line_offset: usize,
     ) {
         let data = node.data.borrow();
-
-        match &data.value {
-            NodeValue::Text(text) => {
-                // Look for [label] patterns in text content
-                let line_num = data.sourcepos.start.line;
-
-                for caps in ref_pattern.captures_iter(text) {
-                    let full_match = caps.get(0).unwrap();
-                    let label = if let Some(explicit_label) = caps.get(2) {
-                        // [text][label] form - use the explicit label
-                        let l = explicit_label.as_str();
-                        if l.is_empty() {
-                            // [text][] form - use the text as label
-                            caps.get(1).map(|m| m.as_str()).unwrap_or("")
-                        } else {
-                            l
-                        }
-                    } else {
-                        // [text] form - use the text as label
-                        caps.get(1).map(|m| m.as_str()).unwrap_or("")
-                    };
-
-                    // Skip empty labels
-                    if label.is_empty() {
-                        continue;
-                    }
-
-                    // Skip footnote references [^name]
-                    if label.starts_with('^') {
-                        continue;
-                    }
-
-                    // Skip GitHub alert markers [!NOTE], [!TIP], etc.
-                    if label.starts_with('!') {
-                        continue;
-                    }
-
-                    // Skip PHP Markdown Extra abbreviations
-                    if abbreviations.contains(label) {
-                        continue;
-                    }
-
-                    // Skip reference definitions that exist in source but comrak didn't parse
-                    // (e.g., when they follow abbreviation definitions without a blank line)
-                    if source_ref_defs.contains(label) {
-                        continue;
-                    }
-
-                    // Check original source to see if this was escaped
-                    if Self::is_escaped_in_source(source_lines, line_num, full_match.as_str()) {
-                        continue;
-                    }
-
-                    warnings.push((line_num, format!("undefined reference link: [{}]", label)));
-                }
-            }
-            // Skip code blocks and inline code - they don't contain reference links
-            NodeValue::CodeBlock(_) | NodeValue::Code(_) => {
-                return;
-            }
-            // Skip other leaf nodes that don't contain text we care about
-            NodeValue::HtmlBlock(_) | NodeValue::HtmlInline(_) => {
-                return;
-            }
-            _ => {}
-        }
+        let is_heading = matches!(&data.value, NodeValue::Heading(_));
+        let is_inline_container = matches!(
+            &data.value,
+            NodeValue::Paragraph | NodeValue::Heading(_) | NodeValue::TableCell
+        );
+        let skip_children = matches!(
+            &data.value,
+            NodeValue::CodeBlock(_)
+                | NodeValue::Link(_)
+                | NodeValue::Image(_)
+                | NodeValue::HtmlBlock(_)
+        );
 
         drop(data);
+        let child_offset = self.consumed_head_offset(node).unwrap_or(line_offset);
+
+        // Scan an inline container exactly once.  This lets a full reference
+        // spanning sibling nodes choose its explicit label without a fragment
+        // scan also reporting its link text.
+        if is_inline_container {
+            let Some(mut inline) =
+                self.collect_undefined_reference_inline(node, child_offset, is_heading)
+            else {
+                return;
+            };
+            self.collect_undefined_reference_ranges(node, &mut inline, child_offset);
+            inline.opener_ranges.sort_unstable();
+            inline.opaque_ranges.sort_unstable();
+            inline.heading_removed_ranges.sort_unstable();
+            self.find_undefined_references_in_text(
+                &inline,
+                (node, child_offset),
+                abbreviations,
+                source_ref_defs,
+                disabled_ranges,
+                undefined_references,
+            );
+            return;
+        }
+
+        if skip_children {
+            return;
+        }
 
         // Recurse into children
         for child in node.children() {
-            Self::walk_ast_for_undefined_refs(
+            self.walk_ast_for_undefined_refs(
                 child,
-                source_lines,
-                ref_pattern,
                 abbreviations,
                 source_ref_defs,
-                warnings,
+                disabled_ranges,
+                undefined_references,
+                child_offset,
             );
         }
     }
 
-    /// Check if a bracket pattern was escaped in the original source.
-    /// Returns true if the pattern appears as `\[...]` in the source.
-    fn is_escaped_in_source(source_lines: &[&str], line_num: usize, pattern: &str) -> bool {
-        if line_num == 0 || line_num > source_lines.len() {
+    /// Extract a container's complete inline source for unresolved-reference
+    /// detection.
+    ///
+    /// Inline node source positions can omit source characters consumed by
+    /// escapes.  The block-level container still spans the complete spelling,
+    /// so use it as the text to scan and use text-node positions only to decide
+    /// which opening brackets are literal inline text.
+    fn collect_undefined_reference_inline<'b>(
+        &self,
+        node: &'b AstNode<'b>,
+        line_offset: usize,
+        heading: bool,
+    ) -> Option<UnresolvedReferenceInline> {
+        let data = node.data.borrow();
+        let sourcepos = data.sourcepos;
+        let description_term = node.parent().is_some_and(|parent| {
+            matches!(&parent.data.borrow().value, NodeValue::DescriptionTerm)
+        });
+        let (text, start_line, start_column) = match &data.value {
+            NodeValue::Heading(heading) if heading.setext => {
+                let start_line = sourcepos.start.line + line_offset;
+                let end_line = sourcepos.end.line.checked_sub(1)?;
+                let end_column = self.source_lines.get(end_line - 1)?.len();
+                (
+                    self.extract_source_range(
+                        start_line,
+                        sourcepos.start.column,
+                        end_line,
+                        end_column,
+                    )?,
+                    start_line,
+                    sourcepos.start.column,
+                )
+            }
+            NodeValue::Heading(heading) => {
+                let start_line = sourcepos.start.line + line_offset;
+                let mut text = self.extract_source_range(
+                    start_line,
+                    sourcepos.start.column,
+                    sourcepos.end.line,
+                    sourcepos.end.column,
+                )?;
+                let prefix = heading.level as usize;
+                let whitespace = text[prefix..]
+                    .find(|character: char| !character.is_ascii_whitespace())
+                    .unwrap_or(text.len() - prefix);
+                let content_start = prefix + whitespace;
+                text.drain(..content_start);
+                Self::strip_atx_closing_sequence(&mut text);
+                (text, start_line, sourcepos.start.column + content_start)
+            }
+            NodeValue::Paragraph if description_term => {
+                let start_line = sourcepos.start.line + line_offset;
+                let end_line = Self::inline_subtree_end_line(node) + line_offset;
+                let end_column = self.source_lines.get(end_line - 1)?.len();
+                (
+                    self.extract_source_range(
+                        start_line,
+                        sourcepos.start.column,
+                        end_line,
+                        end_column,
+                    )?,
+                    start_line,
+                    sourcepos.start.column,
+                )
+            }
+            _ => {
+                let start_line = sourcepos.start.line + line_offset;
+                (
+                    self.extract_source_range(
+                        start_line,
+                        sourcepos.start.column,
+                        sourcepos.end.line,
+                        sourcepos.end.column,
+                    )?,
+                    start_line,
+                    sourcepos.start.column,
+                )
+            }
+        };
+        drop(data);
+
+        let blockquote_indent = Self::blockquote_outer_indent(node);
+        let mut rebuilt = String::with_capacity(text.len());
+        let mut line_columns = Vec::new();
+        for (line_index, source_line) in text.split('\n').enumerate() {
+            if line_index > 0 {
+                rebuilt.push('\n');
+            }
+            let prefix = if line_index > 0
+                && let Some(indent) = blockquote_indent
+            {
+                Self::blockquote_prefix_len(source_line, indent)
+            } else {
+                0
+            };
+            line_columns.push(if line_index == 0 {
+                start_column
+            } else {
+                prefix + 1
+            });
+            rebuilt.push_str(&source_line[prefix..]);
+        }
+        let text = rebuilt;
+        let mut line_offsets = vec![0];
+        line_offsets.extend(text.match_indices('\n').map(|(offset, _)| offset + 1));
+        #[cfg(test)]
+        UNRESOLVED_SOURCE_INDEX_ENTRIES.with(|entries| {
+            entries.set(entries.get().max(line_offsets.len()));
+        });
+
+        Some(UnresolvedReferenceInline {
+            text,
+            opener_ranges: Vec::new(),
+            opaque_ranges: Vec::new(),
+            heading_removed_ranges: Vec::new(),
+            heading,
+            start_line,
+            line_columns,
+            line_offsets,
+        })
+    }
+
+    /// Build minimal definitions that keep resolved reference nodes intact when
+    /// an inline container is reparsed to render its unresolved labels.
+    fn collect_resolved_reference_definitions<'b>(
+        &self,
+        node: &'b AstNode<'b>,
+        line_offset: usize,
+    ) -> String {
+        let mut seen = std::collections::HashSet::new();
+        let mut definitions = String::new();
+        for descendant in node.descendants() {
+            if !matches!(
+                &descendant.data.borrow().value,
+                NodeValue::Link(_) | NodeValue::Image(_)
+            ) {
+                continue;
+            }
+            let Some((text, label)) =
+                self.get_reference_style_info_shifted(descendant, line_offset)
+            else {
+                continue;
+            };
+            let label = label.strip_prefix('\x01').unwrap_or(&label);
+            let label = if label.is_empty() { &text } else { label };
+            if !seen.insert(label.to_string()) {
+                continue;
+            }
+            definitions.push('[');
+            definitions.push_str(label);
+            definitions.push_str("]: .\n");
+        }
+        definitions
+    }
+
+    /// Return the indentation before the outermost blockquote marker.
+    fn blockquote_outer_indent<'b>(node: &'b AstNode<'b>) -> Option<usize> {
+        let mut ancestor = node.parent();
+        let mut indent = None;
+        while let Some(parent) = ancestor {
+            if matches!(
+                &parent.data.borrow().value,
+                NodeValue::BlockQuote | NodeValue::MultilineBlockQuote(_)
+            ) {
+                indent = Some(
+                    parent
+                        .data
+                        .borrow()
+                        .sourcepos
+                        .start
+                        .column
+                        .saturating_sub(1),
+                );
+            }
+            ancestor = parent.parent();
+        }
+        indent
+    }
+
+    /// Return the byte length of the blockquote container prefix on a source
+    /// continuation line.
+    fn blockquote_prefix_len(line: &str, outer_indent: usize) -> usize {
+        let bytes = line.as_bytes();
+        let mut cursor = 0;
+        let mut column = 0;
+        let mut prefix = 0;
+        loop {
+            let mut marker = cursor;
+            let mut marker_column = column;
+            while let Some(byte) = bytes.get(marker) {
+                match byte {
+                    b' ' => marker_column += 1,
+                    b'\t' => marker_column += 4 - marker_column % 4,
+                    _ => break,
+                }
+                marker += 1;
+            }
+            let allowed_indent = if prefix == 0 { outer_indent + 3 } else { 3 };
+            if marker_column - column > allowed_indent || bytes.get(marker) != Some(&b'>') {
+                break;
+            }
+            cursor = marker + 1;
+            column = marker_column + 1;
+            if bytes
+                .get(cursor)
+                .is_some_and(|byte| matches!(byte, b' ' | b'\t'))
+            {
+                column += if bytes[cursor] == b'\t' {
+                    4 - column % 4
+                } else {
+                    1
+                };
+                cursor += 1;
+            }
+            prefix = cursor;
+        }
+        prefix
+    }
+
+    fn inline_subtree_end_line<'b>(node: &'b AstNode<'b>) -> usize {
+        node.children()
+            .map(Self::inline_subtree_end_line)
+            .fold(node.data.borrow().sourcepos.end.line, usize::max)
+    }
+
+    fn strip_atx_closing_sequence(text: &mut String) {
+        let trimmed = text.trim_end_matches([' ', '\t']);
+        let hashes = trimmed.trim_end_matches('#');
+        if hashes.len() == trimmed.len() {
+            return;
+        }
+        let Some(previous) = hashes.chars().next_back() else {
+            text.clear();
+            return;
+        };
+        if !previous.is_ascii_whitespace() {
+            return;
+        }
+        text.truncate(hashes.trim_end_matches([' ', '\t']).len());
+    }
+
+    /// Record ordinary-text opener spans and opaque inline-node spans.
+    fn collect_undefined_reference_ranges<'b>(
+        &self,
+        node: &'b AstNode<'b>,
+        inline: &mut UnresolvedReferenceInline,
+        line_offset: usize,
+    ) {
+        let data = node.data.borrow();
+        let text = matches!(&data.value, NodeValue::Text(_));
+        let heading_removed = inline.heading && matches!(&data.value, NodeValue::HtmlInline(_));
+        let opaque = matches!(
+            &data.value,
+            NodeValue::Code(_)
+                | NodeValue::HtmlInline(_)
+                | NodeValue::Raw(_)
+                | NodeValue::Math(_)
+                | NodeValue::FootnoteReference(_)
+                | NodeValue::WikiLink(_)
+                | NodeValue::EscapedTag(_)
+        );
+        if text || opaque {
+            let range = {
+                let sourcepos = data.sourcepos;
+                let start_line = sourcepos.start.line + line_offset;
+                let end_line = sourcepos.end.line + line_offset;
+                let Some(start) =
+                    Self::inline_source_offset(inline, start_line, sourcepos.start.column)
+                else {
+                    return;
+                };
+                let Some(mut end) =
+                    Self::inline_source_offset(inline, end_line, sourcepos.end.column)
+                else {
+                    return;
+                };
+                end = end.saturating_add(1).min(inline.text.len());
+                (start, end)
+            };
+            if range.0 < range.1 {
+                if text {
+                    inline.opener_ranges.push(range);
+                } else {
+                    inline.opaque_ranges.push(range);
+                    if heading_removed {
+                        inline.heading_removed_ranges.push(range);
+                    }
+                }
+            }
+            return;
+        }
+        drop(data);
+
+        for child in node.children() {
+            self.collect_undefined_reference_ranges(child, inline, line_offset);
+        }
+    }
+
+    fn inline_source_offset(
+        inline: &UnresolvedReferenceInline,
+        line: usize,
+        column: usize,
+    ) -> Option<usize> {
+        let line_offset = line.checked_sub(inline.start_line)?;
+        let offset = *inline.line_offsets.get(line_offset)?;
+        let start_column = *inline.line_columns.get(line_offset)?;
+        let column_offset = column.checked_sub(start_column)?;
+        Some(offset + column_offset)
+    }
+
+    fn is_text_opener_at(inline: &UnresolvedReferenceInline, offset: usize) -> bool {
+        let range = inline
+            .opener_ranges
+            .partition_point(|(_, to)| *to <= offset);
+        inline
+            .opener_ranges
+            .get(range)
+            .is_some_and(|(from, to)| *from <= offset && offset < *to)
+    }
+
+    fn is_opaque_at(inline: &UnresolvedReferenceInline, offset: usize) -> bool {
+        let range = inline
+            .opaque_ranges
+            .partition_point(|(_, to)| *to <= offset);
+        inline
+            .opaque_ranges
+            .get(range)
+            .is_some_and(|(from, to)| *from <= offset && offset < *to)
+    }
+
+    fn heading_removed_range_end(
+        inline: &UnresolvedReferenceInline,
+        offset: usize,
+    ) -> Option<usize> {
+        let range = inline
+            .heading_removed_ranges
+            .partition_point(|(_, to)| *to <= offset);
+        inline
+            .heading_removed_ranges
+            .get(range)
+            .filter(|(from, to)| *from <= offset && offset < *to)
+            .map(|(_, to)| *to)
+    }
+
+    fn inline_source_line(inline: &UnresolvedReferenceInline, offset: usize) -> usize {
+        let line = inline
+            .line_offsets
+            .partition_point(|line_start| *line_start <= offset)
+            .saturating_sub(1);
+        inline.start_line + line
+    }
+
+    fn find_undefined_references_in_text<'b>(
+        &self,
+        inline: &UnresolvedReferenceInline,
+        container: (&'b AstNode<'b>, usize),
+        abbreviations: &std::collections::HashSet<String>,
+        source_ref_defs: &std::collections::HashSet<String>,
+        disabled_ranges: &[(usize, usize)],
+        undefined_references: &mut Vec<UndefinedReference>,
+    ) {
+        let text = &inline.text;
+        let bytes = text.as_bytes();
+        let mut start = 0;
+        let mut opener_range = 0;
+        let mut references = Vec::new();
+        while start < bytes.len() {
+            while inline
+                .opener_ranges
+                .get(opener_range)
+                .is_some_and(|(_, to)| *to <= start)
+            {
+                opener_range += 1;
+            }
+            let is_text_opener = inline
+                .opener_ranges
+                .get(opener_range)
+                .is_some_and(|(from, to)| *from <= start && start < *to);
+            if bytes[start] != b'[' || Self::is_escaped_at(text, start) || !is_text_opener {
+                start += text[start..]
+                    .chars()
+                    .next()
+                    .map(char::len_utf8)
+                    .unwrap_or(1);
+                continue;
+            }
+
+            let Some(first_end) = Self::find_reference_label_end(inline, start + 1) else {
+                start += 1;
+                continue;
+            };
+            let first_label = &text[start + 1..first_end];
+            if first_label.is_empty() {
+                start = first_end + 1;
+                continue;
+            }
+
+            let mut raw_label_start = start + 1;
+            let mut raw_label_end = first_end;
+            let mut match_end = first_end + 1;
+            if bytes.get(match_end) == Some(&b'[')
+                && Self::is_text_opener_at(inline, match_end)
+                && let Some(second_end) = Self::find_reference_label_end(inline, match_end + 1)
+            {
+                let explicit_label = &text[match_end + 1..second_end];
+                if !normalize_reference_key(explicit_label).is_empty() {
+                    raw_label_start = match_end + 1;
+                    raw_label_end = second_end;
+                }
+                match_end = second_end + 1;
+            }
+            let raw_label = &text[raw_label_start..raw_label_end];
+
+            if raw_label.starts_with('^') {
+                start = match_end;
+                continue;
+            }
+
+            let line = Self::inline_source_line(inline, start);
+            let raw_key = normalize_reference_key(raw_label);
+            let warning_exempt =
+                abbreviations.contains(&raw_key) || source_ref_defs.contains(&raw_key);
+            let verbatim =
+                warning_exempt && self.is_verbatim_reference_definition(inline, start, match_end);
+            references.push((
+                line,
+                raw_label_start,
+                raw_label_end,
+                Self::is_line_in_ranges(line, disabled_ranges),
+                warning_exempt,
+                verbatim,
+            ));
+            start = match_end;
+        }
+
+        if references.is_empty() {
+            return;
+        }
+        let resolved_reference_definitions =
+            self.collect_resolved_reference_definitions(container.0, container.1);
+        let heading_ranges: Vec<_> = references
+            .iter()
+            .filter(|(_, _, _, disabled, _, verbatim)| inline.heading && !disabled && !verbatim)
+            .map(|(_, label_start, label_end, _, _, _)| (*label_start, *label_end))
+            .collect();
+        let mut heading_labels = self
+            .render_unresolved_heading_reference_labels(
+                text,
+                &resolved_reference_definitions,
+                &heading_ranges,
+            )
+            .into_iter();
+        let inline_ranges: Vec<_> = references
+            .iter()
+            .filter(|(_, _, _, disabled, _, verbatim)| !inline.heading && !disabled && !verbatim)
+            .map(|(_, label_start, label_end, _, _, _)| (*label_start, *label_end))
+            .collect();
+        let mut inline_labels = self
+            .render_unresolved_inline_reference_labels(
+                text,
+                &resolved_reference_definitions,
+                &inline_ranges,
+            )
+            .into_iter();
+        for (line, label_start, label_end, disabled, warning_exempt, verbatim) in references {
+            let raw_label = &text[label_start..label_end];
+            let emitted_label = if disabled || verbatim {
+                raw_label.to_string()
+            } else if inline.heading {
+                heading_labels
+                    .next()
+                    .unwrap_or_else(|| self.render_unresolved_reference_label(raw_label))
+            } else {
+                inline_labels
+                    .next()
+                    .unwrap_or_else(|| self.render_unresolved_reference_label(raw_label))
+            };
+            undefined_references.push(UndefinedReference {
+                line,
+                label: emitted_label,
+                warning_exempt,
+            });
+        }
+    }
+
+    fn is_verbatim_reference_definition(
+        &self,
+        inline: &UnresolvedReferenceInline,
+        label_start: usize,
+        match_end: usize,
+    ) -> bool {
+        if inline.text.as_bytes().get(match_end) != Some(&b':') {
             return false;
         }
+        let line_index = inline
+            .line_offsets
+            .partition_point(|line_start| *line_start <= label_start)
+            .saturating_sub(1);
+        let source_line = inline.start_line + line_index;
+        let Some(source) = self.source_lines.get(source_line - 1) else {
+            return false;
+        };
+        let source_column = inline.line_columns[line_index].saturating_sub(1)
+            + label_start.saturating_sub(inline.line_offsets[line_index]);
+        let Some(prefix) = source.get(..source_column) else {
+            return false;
+        };
+        let whitespace = |byte: &u8| matches!(byte, b' ' | b'\t');
+        prefix.as_bytes().iter().all(whitespace)
+            || prefix
+                .strip_suffix('*')
+                .is_some_and(|prefix| prefix.as_bytes().iter().all(whitespace))
+    }
 
-        let line = source_lines[line_num - 1];
-
-        // Look for the pattern in the line and check if it's preceded by backslash
-        if let Some(pos) = line.find(pattern)
-            && pos > 0
-        {
-            let bytes = line.as_bytes();
-            // Check if preceded by backslash (and not double backslash)
-            if bytes[pos - 1] == b'\\' && (pos < 2 || bytes[pos - 2] != b'\\') {
-                return true;
+    /// Return the byte offset of the unescaped `]` that closes a label.
+    fn find_reference_label_end(
+        inline: &UnresolvedReferenceInline,
+        mut offset: usize,
+    ) -> Option<usize> {
+        let text = &inline.text;
+        let bytes = text.as_bytes();
+        while offset < bytes.len() {
+            if let Some(end) = Self::heading_removed_range_end(inline, offset) {
+                offset = end;
+                continue;
+            }
+            match bytes[offset] {
+                b'\0' | b'[' => return None,
+                b']' if Self::is_opaque_at(inline, offset) => return None,
+                b']' => return Some(offset),
+                b'\\' => {
+                    offset += 1;
+                    if offset < bytes.len() {
+                        offset += text[offset..]
+                            .chars()
+                            .next()
+                            .map(char::len_utf8)
+                            .unwrap_or(1);
+                    }
+                }
+                _ => {
+                    offset += text[offset..]
+                        .chars()
+                        .next()
+                        .map(char::len_utf8)
+                        .unwrap_or(1);
+                }
             }
         }
+        None
+    }
 
-        false
+    fn is_escaped_at(text: &str, offset: usize) -> bool {
+        let bytes = text.as_bytes();
+        let mut previous = offset;
+        let mut slashes = 0;
+        while previous > 0 && bytes[previous - 1] == b'\\' {
+            previous -= 1;
+            slashes += 1;
+        }
+        slashes % 2 == 1
+    }
+
+    /// Render label source in link-text context without serializing the
+    /// surrounding document.
+    fn render_unresolved_reference_label(&self, raw_label: &str) -> String {
+        let source = format!("[{raw_label}](.)");
+        let arena = Arena::new();
+        let options = crate::comrak_options(self.options);
+        let root = parse_document(&arena, &source, &options);
+        let link = root.first_child().and_then(|block| {
+            block
+                .children()
+                .find(|child| matches!(&child.data.borrow().value, NodeValue::Link(_)))
+        });
+        let Some(link) = link else {
+            return raw_label.replace('\n', " ");
+        };
+
+        let source_lines = source.lines().collect();
+        let mut serializer = Serializer::new(self.options, source_lines, false);
+        let mut rendered = String::new();
+        for child in link.children() {
+            serializer.collect_inline_node(child, &mut rendered);
+        }
+        rendered.retain(|character| {
+            character != super::MATH_TOKEN_OPEN && character != super::MATH_TOKEN_CLOSE
+        });
+        rendered.replace(['\0', '\n'], " ")
+    }
+
+    /// Render unresolved labels in the context of their complete inline block.
+    ///
+    /// Punctuation conversion can depend on text before a label, most notably
+    /// for deciding whether a straight quote opens or closes.  Mark all labels
+    /// and render the block once so each reserved label matches its eventual
+    /// document spelling without introducing one parse per reference.
+    fn render_unresolved_inline_reference_labels(
+        &self,
+        inline_source: &str,
+        resolved_reference_definitions: &str,
+        labels: &[(usize, usize)],
+    ) -> Vec<String> {
+        if labels.is_empty() {
+            return Vec::new();
+        }
+        let render_fallback = || {
+            labels
+                .iter()
+                .map(|&(start, end)| {
+                    inline_source
+                        .get(start..end)
+                        .map_or_else(String::new, |label| {
+                            self.render_unresolved_reference_label(label)
+                        })
+                })
+                .collect()
+        };
+        let (open_marker, close_marker) = Self::unused_reference_label_markers(inline_source);
+        let marker_capacity = labels.len() * (open_marker.len() + close_marker.len());
+        let mut marked_source = String::with_capacity(inline_source.len() + marker_capacity);
+        let mut source_offset = 0;
+        for &(label_start, label_end) in labels {
+            let Some(marker_start) = label_start.checked_sub(1) else {
+                return render_fallback();
+            };
+            let Some(marker_end) = label_end.checked_add(1) else {
+                return render_fallback();
+            };
+            if marker_start < source_offset
+                || label_end < label_start
+                || marker_end > inline_source.len()
+            {
+                return render_fallback();
+            }
+            marked_source.push_str(&inline_source[source_offset..marker_start]);
+            marked_source.push_str(&open_marker);
+            marked_source.push_str(&inline_source[marker_start..marker_end]);
+            marked_source.push_str(&close_marker);
+            source_offset = marker_end;
+        }
+        marked_source.push_str(&inline_source[source_offset..]);
+        marked_source.retain(|character| character != '\0');
+
+        let source = if resolved_reference_definitions.is_empty() {
+            marked_source
+        } else {
+            format!("{marked_source}\n\n{resolved_reference_definitions}")
+        };
+        let arena = Arena::new();
+        let options = crate::comrak_options(self.options);
+        let root = parse_document(&arena, &source, &options);
+        let Some(paragraph) = root
+            .children()
+            .find(|child| matches!(&child.data.borrow().value, NodeValue::Paragraph))
+        else {
+            return render_fallback();
+        };
+
+        let source_lines = source.lines().collect();
+        let mut serializer = Serializer::new(self.options, source_lines, false);
+        let mut rendered = String::new();
+        serializer.collect_inline_content(paragraph, &mut rendered);
+        rendered.retain(|character| {
+            character != super::MATH_TOKEN_OPEN && character != super::MATH_TOKEN_CLOSE
+        });
+
+        let mut rendered_labels = Vec::with_capacity(labels.len());
+        let mut rendered_offset = 0;
+        for _ in labels {
+            let Some(open) = rendered[rendered_offset..].find(&open_marker) else {
+                return render_fallback();
+            };
+            let marked_start = rendered_offset + open + open_marker.len();
+            let Some(close) = rendered[marked_start..].find(&close_marker) else {
+                return render_fallback();
+            };
+            let marked_end = marked_start + close;
+            let Some(label) =
+                Self::strip_rendered_reference_brackets(&rendered[marked_start..marked_end])
+            else {
+                return render_fallback();
+            };
+            rendered_labels.push(label.replace(['\0', '\n'], " "));
+            rendered_offset = marked_end + close_marker.len();
+        }
+        rendered_labels
+    }
+
+    /// Render an unresolved label in the context of its complete heading.
+    ///
+    /// Sentence casing depends on text before the label, so rendering the label
+    /// alone can capitalize a word that stays lowercase in the real heading.
+    fn render_unresolved_heading_reference_labels(
+        &self,
+        heading_source: &str,
+        resolved_reference_definitions: &str,
+        labels: &[(usize, usize)],
+    ) -> Vec<String> {
+        if labels.is_empty() {
+            return Vec::new();
+        }
+        let render_fallback = || {
+            labels
+                .iter()
+                .map(|&(start, end)| {
+                    heading_source
+                        .get(start..end)
+                        .map_or_else(String::new, |label| {
+                            self.render_unresolved_reference_label(label)
+                        })
+                })
+                .collect()
+        };
+        #[cfg(test)]
+        HEADING_REFERENCE_RENDER_PASSES.with(|passes| passes.set(passes.get() + 1));
+        let (open_marker, close_marker) = Self::unused_reference_label_markers(heading_source);
+        let marker_capacity = labels.len() * (open_marker.len() + close_marker.len());
+        let mut marked_source = String::with_capacity(heading_source.len() + marker_capacity);
+        let mut source_offset = 0;
+        for &(label_start, label_end) in labels {
+            let Some(marker_start) = label_start.checked_sub(1) else {
+                return render_fallback();
+            };
+            let Some(marker_end) = label_end.checked_add(1) else {
+                return render_fallback();
+            };
+            if marker_start < source_offset
+                || label_end < label_start
+                || marker_end > heading_source.len()
+            {
+                return render_fallback();
+            }
+            marked_source.push_str(&heading_source[source_offset..marker_start]);
+            marked_source.push_str(&open_marker);
+            marked_source.push_str(&heading_source[marker_start..marker_end]);
+            marked_source.push_str(&close_marker);
+            source_offset = marker_end;
+        }
+        marked_source.push_str(&heading_source[source_offset..]);
+        marked_source.retain(|character| character != '\0');
+
+        let source = if resolved_reference_definitions.is_empty() {
+            format!("# {marked_source}")
+        } else {
+            format!("# {marked_source}\n\n{resolved_reference_definitions}")
+        };
+        let arena = Arena::new();
+        let options = crate::comrak_options(self.options);
+        let root = parse_document(&arena, &source, &options);
+        let Some(heading) = root
+            .children()
+            .find(|child| matches!(&child.data.borrow().value, NodeValue::Heading(_)))
+        else {
+            return render_fallback();
+        };
+
+        let source_lines = source.lines().collect();
+        let mut serializer = Serializer::new(self.options, source_lines, false);
+        let heading_text = serializer.collect_text(heading);
+        let (heading_body, _) = super::heading::split_trailing_explicit_anchor(&heading_text);
+        let rendered = if self.options.heading_sentence_case {
+            super::heading::to_sentence_case(
+                heading_body,
+                &self.options.heading_proper_nouns,
+                &self.options.heading_common_nouns,
+            )
+        } else {
+            heading_body.to_string()
+        };
+
+        let mut rendered_labels = Vec::with_capacity(labels.len());
+        let mut rendered_offset = 0;
+        for _ in labels {
+            let Some(open) = rendered[rendered_offset..].find(&open_marker) else {
+                return render_fallback();
+            };
+            let marked_start = rendered_offset + open + open_marker.len();
+            let Some(close) = rendered[marked_start..].find(&close_marker) else {
+                return render_fallback();
+            };
+            let marked_end = marked_start + close;
+            let Some(label) =
+                Self::strip_rendered_reference_brackets(&rendered[marked_start..marked_end])
+            else {
+                return render_fallback();
+            };
+            rendered_labels.push(label.to_string());
+            rendered_offset = marked_end + close_marker.len();
+        }
+        rendered_labels
+    }
+
+    fn strip_rendered_reference_brackets(rendered: &str) -> Option<&str> {
+        rendered
+            .strip_prefix('[')
+            .or_else(|| rendered.strip_prefix("\\["))
+            .and_then(|label| label.strip_suffix(']'))
+    }
+
+    /// Build two markers that cannot occur in the source.
+    fn unused_reference_label_markers(source: &str) -> (String, String) {
+        const BMP_START: u32 = 0xe000;
+        const BMP_END: u32 = 0xf8ff;
+        const PLANE_15_START: u32 = 0xf0000;
+        const PLANE_15_END: u32 = 0xffffd;
+        const PLANE_16_START: u32 = 0x100000;
+        const PLANE_16_END: u32 = 0x10fffd;
+        const BMP_COUNT: usize = (BMP_END - BMP_START + 1) as usize;
+        const PLANE_COUNT: usize = (PLANE_15_END - PLANE_15_START + 1) as usize;
+        const PRIVATE_USE_COUNT: usize = BMP_COUNT + PLANE_COUNT * 2;
+
+        let private_use_index = |character: char| {
+            let value = character as u32;
+            match value {
+                BMP_START..=BMP_END => Some((value - BMP_START) as usize),
+                PLANE_15_START..=PLANE_15_END => {
+                    Some(BMP_COUNT + (value - PLANE_15_START) as usize)
+                }
+                PLANE_16_START..=PLANE_16_END => {
+                    Some(BMP_COUNT + PLANE_COUNT + (value - PLANE_16_START) as usize)
+                }
+                _ => None,
+            }
+        };
+        let private_use_character = |index: usize| {
+            let value = if index < BMP_COUNT {
+                BMP_START + index as u32
+            } else if index < BMP_COUNT + PLANE_COUNT {
+                PLANE_15_START + (index - BMP_COUNT) as u32
+            } else {
+                PLANE_16_START + (index - BMP_COUNT - PLANE_COUNT) as u32
+            };
+            char::from_u32(value).unwrap()
+        };
+
+        let mut used = vec![0_u64; PRIVATE_USE_COUNT.div_ceil(64)];
+        for character in source.chars() {
+            if let Some(index) = private_use_index(character) {
+                used[index / 64] |= 1 << (index % 64);
+            }
+        }
+        let mut unused = (0..PRIVATE_USE_COUNT)
+            .filter(|index| used[index / 64] & (1 << (index % 64)) == 0)
+            .map(private_use_character);
+        if let (Some(open), Some(close)) = (unused.next(), unused.next()) {
+            return (open.to_string(), close.to_string());
+        }
+
+        // A source containing every private-use scalar is already large.
+        // Keep even that pathological fallback linear by finding both maximum
+        // runs in a single pass instead of repeatedly rescanning the source.
+        let mut open_max = 0;
+        let mut open_run = 0;
+        let mut close_max = 0;
+        let mut close_run = 0;
+        for character in source.chars() {
+            if character == '\u{e000}' {
+                open_run += 1;
+                open_max = open_max.max(open_run);
+            } else {
+                open_run = 0;
+            }
+            if character == '\u{e001}' {
+                close_run += 1;
+                close_max = close_max.max(close_run);
+            } else {
+                close_run = 0;
+            }
+        }
+        (
+            std::iter::repeat_n('\u{e000}', open_max + 1).collect(),
+            std::iter::repeat_n('\u{e001}', close_max + 1).collect(),
+        )
     }
 
     pub(super) fn serialize_thematic_break(&mut self) {
@@ -1843,7 +2748,57 @@ impl<'a> Serializer<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::Serializer;
+    use super::{
+        HEADING_REFERENCE_RENDER_PASSES, SOURCE_EXCLUSION_RANGE_SCANS, Serializer,
+        UNRESOLVED_SOURCE_INDEX_ENTRIES,
+    };
+    use crate::{Options, format_with_warnings};
+
+    #[test]
+    fn test_heading_references_render_in_one_pass() {
+        HEADING_REFERENCE_RENDER_PASSES.with(|passes| passes.set(0));
+        let labels = (0..64)
+            .map(|index| format!("[missing {index}]"))
+            .collect::<Vec<_>>()
+            .join(" ");
+        let result = format_with_warnings(&format!("# {labels}\n"), &Options::default()).unwrap();
+        assert_eq!(result.warnings.len(), 64);
+        assert_eq!(
+            result.warnings.first().unwrap().message,
+            "undefined reference link: [missing 0]"
+        );
+        assert_eq!(
+            result.warnings.last().unwrap().message,
+            "undefined reference link: [missing 63]"
+        );
+        HEADING_REFERENCE_RENDER_PASSES.with(|passes| assert_eq!(passes.get(), 1));
+    }
+
+    #[test]
+    fn test_reference_markers_stay_bounded_for_repeated_pua() {
+        let source = format!("{}{}", "\u{e000}".repeat(4_096), "\u{e001}".repeat(4_096));
+        let (open, close) = Serializer::unused_reference_label_markers(&source);
+        assert!(open.chars().count() <= 2);
+        assert!(close.chars().count() <= 2);
+    }
+
+    #[test]
+    fn test_source_index_scales_with_lines() {
+        UNRESOLVED_SOURCE_INDEX_ENTRIES.with(|entries| entries.set(0));
+        format_with_warnings(&"x".repeat(64 * 1024), &Options::default()).unwrap();
+        UNRESOLVED_SOURCE_INDEX_ENTRIES.with(|entries| assert_eq!(entries.get(), 1));
+    }
+
+    #[test]
+    fn test_source_definition_exclusions_do_not_scan_ranges() {
+        let source = (0..64)
+            .map(|index| format!("~~~~ text\n[label {index}]: example\n~~~~\n"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        SOURCE_EXCLUSION_RANGE_SCANS.with(|scans| scans.set(0));
+        format_with_warnings(&source, &Options::default()).unwrap();
+        SOURCE_EXCLUSION_RANGE_SCANS.with(|scans| assert_eq!(scans.get(), 0));
+    }
 
     /// The text a reference definition carries after its label's colon, and
     /// what of a title it leaves open for the lines below to close.

--- a/src/serializer/document.rs
+++ b/src/serializer/document.rs
@@ -1768,6 +1768,8 @@ impl<'a> Serializer<'a> {
         disabled_ranges: &[(usize, usize)],
     ) -> Vec<UndefinedReference> {
         let mut undefined_references = Vec::new();
+        let directive_proper_nouns = self.directive_proper_nouns.clone();
+        let directive_common_nouns = self.directive_common_nouns.clone();
 
         self.walk_ast_for_undefined_refs(
             node,
@@ -1777,6 +1779,8 @@ impl<'a> Serializer<'a> {
             &mut undefined_references,
             0,
         );
+        self.directive_proper_nouns = directive_proper_nouns;
+        self.directive_common_nouns = directive_common_nouns;
 
         undefined_references
     }
@@ -1806,6 +1810,7 @@ impl<'a> Serializer<'a> {
         );
 
         drop(data);
+        self.apply_noun_directive(node);
         let child_offset = self.consumed_head_offset(node).unwrap_or(line_offset);
 
         // Scan an inline container exactly once.  This lets a full reference
@@ -2612,11 +2617,11 @@ impl<'a> Serializer<'a> {
         let heading_text = serializer.collect_text(heading);
         let (heading_body, _) = super::heading::split_trailing_explicit_anchor(&heading_text);
         let rendered = if self.options.heading_sentence_case {
-            super::heading::to_sentence_case(
-                heading_body,
-                &self.options.heading_proper_nouns,
-                &self.options.heading_common_nouns,
-            )
+            let mut proper_nouns = self.options.heading_proper_nouns.clone();
+            proper_nouns.extend(self.directive_proper_nouns.clone());
+            let mut common_nouns = self.options.heading_common_nouns.clone();
+            common_nouns.extend(self.directive_common_nouns.clone());
+            super::heading::to_sentence_case(heading_body, &proper_nouns, &common_nouns)
         } else {
             heading_body.to_string()
         };

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -87,9 +87,19 @@ pub fn serialize_with_source_and_warnings<'a>(
     options: &Options,
     source: Option<&str>,
 ) -> SerializeResult {
+    serialize_with_source_and_warnings_and_replacements(node, options, source, Vec::new())
+}
+
+pub(crate) fn serialize_with_source_and_warnings_and_replacements<'a>(
+    node: &'a AstNode<'a>,
+    options: &Options,
+    source: Option<&str>,
+    replacements: Vec<(String, String)>,
+) -> SerializeResult {
     let source_lines: Vec<&str> = source.map(|s| s.lines().collect()).unwrap_or_default();
     let source_ends_with_newline = source.is_some_and(|s| s.ends_with('\n'));
-    let mut serializer = Serializer::new(options, source_lines, source_ends_with_newline);
+    let mut serializer = Serializer::new(options, source_lines, source_ends_with_newline)
+        .with_reference_label_replacements(replacements);
     serializer.serialize_node(node);
     SerializeResult {
         output: strip_math_sentinels(serializer.output),
@@ -104,6 +114,7 @@ pub fn serialize_with_code_formatter<'a>(
     options: &Options,
     source: Option<&str>,
     code_formatter: CodeFormatterCallback,
+    replacements: Vec<(String, String)>,
 ) -> SerializeResult {
     let source_lines: Vec<&str> = source.map(|s| s.lines().collect()).unwrap_or_default();
     let source_ends_with_newline = source.is_some_and(|s| s.ends_with('\n'));
@@ -112,7 +123,8 @@ pub fn serialize_with_code_formatter<'a>(
         source_lines,
         source_ends_with_newline,
         code_formatter,
-    );
+    )
+    .with_reference_label_replacements(replacements);
     serializer.serialize_node(node);
     SerializeResult {
         output: strip_math_sentinels(serializer.output),
@@ -313,10 +325,8 @@ impl<'a> Serializer<'a> {
     /// Record that a reference definition has been written out, so that later
     /// sections neither repeat it nor reuse its label for a different target.
     fn mark_reference_emitted(&mut self, reference: &ReferenceLink) {
-        self.emitted_references.insert(
-            state::normalize_reference_key(&reference.label),
-            reference.clone(),
-        );
+        self.emitted_references
+            .insert(self.reference_key(&reference.label), reference.clone());
     }
 
     /// Extract numeric value from a reference label like "123" or "#123"

--- a/src/serializer/state.rs
+++ b/src/serializer/state.rs
@@ -6,6 +6,12 @@ use comrak::nodes::{AstNode, ListType, NodeValue};
 
 use crate::Options;
 
+#[cfg(test)]
+std::thread_local! {
+    static REFERENCE_LABEL_REPLACEMENT_SCANS: std::cell::Cell<usize> =
+        const { std::cell::Cell::new(0) };
+}
+
 /// The current formatting skip mode.
 ///
 /// Controls whether and how formatting should be skipped for content.
@@ -107,6 +113,9 @@ pub struct ReferenceLink {
 /// parser reject the whole link, so a generated label must stay within it.
 const MAX_REFERENCE_LABEL_BYTES: usize = 1000;
 
+/// Prefix shared by the collision-free placeholders produced in MDX mode.
+const MDX_REFERENCE_LABEL_TOKEN_PREFIX: &str = "<!--hongdown-mdx:";
+
 /// Normalize a reference label into the key used to look it up.
 ///
 /// CommonMark matches reference labels after collapsing internal whitespace
@@ -114,12 +123,15 @@ const MAX_REFERENCE_LABEL_BYTES: usize = 1000;
 /// spacing or case refer to the same definition and must share a single key.
 /// This mirrors comrak's `normalize_label(_, Case::Fold)`, down to using the
 /// same case folding implementation: plain lowercasing would miss pairs such
-/// as `Straße` and `STRASSE`.  The internal SoftBreak marker is treated as
-/// the space it will be emitted as.
+/// as `Straße` and `STRASSE`.  Internal wrapping markers are normalized to
+/// their emitted form: a SoftBreak becomes a space, while math sentinels
+/// disappear.  Backslashes remain significant because comrak keeps them in
+/// reference-label lookup keys.
 pub fn normalize_reference_key(label: &str) -> String {
-    caseless::default_case_fold_str(&super::escape::normalize_whitespace(
-        &label.replace('\x00', " "),
-    ))
+    let emitted = label
+        .replace('\x00', " ")
+        .replace([super::MATH_TOKEN_OPEN, super::MATH_TOKEN_CLOSE], "");
+    caseless::default_case_fold_str(&super::escape::normalize_whitespace(&emitted))
 }
 
 /// The longest suffix [`numbered_reference_label`] appends, in bytes: a space
@@ -327,6 +339,9 @@ pub struct Serializer<'a> {
     /// normalized key.  Such a link cannot be relabelled, so it holds its label
     /// against formatted links, which can be given a derived one instead.
     pub verbatim_reference_claims: std::collections::HashMap<String, ReferenceLink>,
+    /// Normalized labels used by unresolved reference syntax.  Numbered label
+    /// allocation must skip them instead of defining them incidentally.
+    pub unresolved_reference_labels: std::collections::HashSet<String>,
     /// Normalized keys of the labels a verbatim copy redefines: their winning
     /// definition lies outside it, so it has to be emitted ahead of the copy or
     /// the copy would shadow it.
@@ -368,6 +383,8 @@ pub struct Serializer<'a> {
     pub directive_proper_nouns: Vec<String>,
     /// Common nouns defined via directives for sentence case (merged with config)
     pub directive_common_nouns: Vec<String>,
+    /// Protected-source tokens and their final output spellings.
+    reference_label_replacements: std::collections::HashMap<String, String>,
     /// Code formatter callback for WASM builds.
     #[cfg(feature = "wasm")]
     pub code_formatter_callback: CodeFormatterCallback,
@@ -395,6 +412,7 @@ impl<'a> Serializer<'a> {
             footnotes: FootnoteSet::new(),
             verbatim_reference_labels: std::collections::HashSet::new(),
             verbatim_reference_claims: std::collections::HashMap::new(),
+            unresolved_reference_labels: std::collections::HashSet::new(),
             shadowed_reference_labels: std::collections::HashSet::new(),
             deferred_references: Vec::new(),
             reference_definition_lines: std::collections::HashMap::new(),
@@ -411,6 +429,7 @@ impl<'a> Serializer<'a> {
             paragraph_first_line_prefix_width: 0,
             directive_proper_nouns: Vec::new(),
             directive_common_nouns: Vec::new(),
+            reference_label_replacements: std::collections::HashMap::new(),
             #[cfg(feature = "wasm")]
             code_formatter_callback: None,
         }
@@ -440,6 +459,7 @@ impl<'a> Serializer<'a> {
             footnotes: FootnoteSet::new(),
             verbatim_reference_labels: std::collections::HashSet::new(),
             verbatim_reference_claims: std::collections::HashMap::new(),
+            unresolved_reference_labels: std::collections::HashSet::new(),
             shadowed_reference_labels: std::collections::HashSet::new(),
             deferred_references: Vec::new(),
             reference_definition_lines: std::collections::HashMap::new(),
@@ -456,8 +476,52 @@ impl<'a> Serializer<'a> {
             paragraph_first_line_prefix_width: 0,
             directive_proper_nouns: Vec::new(),
             directive_common_nouns: Vec::new(),
+            reference_label_replacements: std::collections::HashMap::new(),
             code_formatter_callback: callback,
         }
+    }
+
+    pub(super) fn with_reference_label_replacements(
+        mut self,
+        replacements: Vec<(String, String)>,
+    ) -> Self {
+        self.reference_label_replacements = replacements.into_iter().collect();
+        self
+    }
+
+    pub(super) fn restore_reference_label(&self, label: &str) -> String {
+        if self.reference_label_replacements.is_empty()
+            || !label.contains(MDX_REFERENCE_LABEL_TOKEN_PREFIX)
+        {
+            return label.to_string();
+        }
+
+        let mut restored = String::with_capacity(label.len());
+        let mut remaining = label;
+        while let Some(start) = remaining.find(MDX_REFERENCE_LABEL_TOKEN_PREFIX) {
+            restored.push_str(&remaining[..start]);
+            let candidate = &remaining[start..];
+            let Some(end) = candidate.find("-->") else {
+                restored.push_str(candidate);
+                return restored;
+            };
+            let token_end = end + 3;
+            let token = &candidate[..token_end];
+            #[cfg(test)]
+            REFERENCE_LABEL_REPLACEMENT_SCANS.with(|scans| scans.set(scans.get() + 1));
+            if let Some(original) = self.reference_label_replacements.get(token) {
+                restored.push_str(original);
+            } else {
+                restored.push_str(token);
+            }
+            remaining = &candidate[token_end..];
+        }
+        restored.push_str(remaining);
+        restored
+    }
+
+    pub(super) fn reference_key(&self, label: &str) -> String {
+        normalize_reference_key(&self.restore_reference_label(label))
     }
 
     /// Add a warning.
@@ -482,16 +546,30 @@ impl<'a> Serializer<'a> {
         node: &'b AstNode<'b>,
         line_offset: usize,
     ) -> Option<String> {
-        if self.source_lines.is_empty() {
-            return None;
-        }
         let sourcepos = node.data.borrow().sourcepos;
         let start_line = sourcepos.start.line + line_offset;
         let end_line = sourcepos.end.line + line_offset;
-        let start_col = sourcepos.start.column;
-        let end_col = sourcepos.end.column;
+        self.extract_source_range(
+            start_line,
+            sourcepos.start.column,
+            end_line,
+            sourcepos.end.column,
+        )
+    }
 
-        if start_line == 0 || end_line == 0 {
+    /// Extract original source text between two inclusive source positions.
+    pub(super) fn extract_source_range(
+        &self,
+        start_line: usize,
+        start_col: usize,
+        end_line: usize,
+        end_col: usize,
+    ) -> Option<String> {
+        if self.source_lines.is_empty() {
+            return None;
+        }
+
+        if start_line == 0 || end_line == 0 || end_line < start_line {
             return None;
         }
 
@@ -583,10 +661,11 @@ impl<'a> Serializer<'a> {
             .or_else(|| self.footnotes.pending_references.get(key).map(|(r, _)| r))
     }
 
-    /// Look up whatever holds `key`, including a label merely claimed by a link
-    /// that is preserved verbatim.  A claim counts as occupying the label even
-    /// before the definition is reserved, because the claiming link cannot be
-    /// relabelled and so must not have its label taken from under it.
+    /// Look up the target-bearing occupant of `key`, including a label merely
+    /// claimed by a link that is preserved verbatim.  A claim counts as
+    /// occupying the label even before the definition is reserved, because the
+    /// claiming link cannot be relabelled and so must not have its label taken
+    /// from under it.
     fn find_occupant(&self, key: &str) -> Option<&ReferenceLink> {
         self.find_reference(key)
             .or_else(|| self.verbatim_reference_claims.get(key))
@@ -604,6 +683,16 @@ impl<'a> Serializer<'a> {
         self.verbatim_reference_labels.contains(key) || self.shadowed_reference_labels.contains(key)
     }
 
+    /// Whether a numbered variant at `key` is unavailable without a target a
+    /// formatted link can share.
+    ///
+    /// Besides definitions copied verbatim, unresolved reference syntax holds
+    /// its label against incidental allocation: emitting a definition for it
+    /// would turn ordinary bracketed text into a link.
+    fn is_numbered_label_unavailable(&self, key: &str) -> bool {
+        self.is_label_carried_verbatim(key) || self.unresolved_reference_labels.contains(key)
+    }
+
     /// Register a reference link and return the label that must be used to
     /// refer to it.
     ///
@@ -617,7 +706,7 @@ impl<'a> Serializer<'a> {
     /// pending_footnote_references instead, along with the current footnote's
     /// reference line for proper flush timing.
     pub fn register_reference(&mut self, label: &str, url: &str, title: &str) -> String {
-        let key = normalize_reference_key(label);
+        let key = self.reference_key(label);
         // Copy the occupant out of the borrow so the maps below can be updated.
         let occupant = self
             .find_occupant(&key)
@@ -638,15 +727,14 @@ impl<'a> Serializer<'a> {
                 label.to_string()
             }
             // Taken: by a different target, or by a definition that a verbatim
-            // copy carries.  A carried definition holds its label document-wide
-            // whether or not a link resolves through it, and its target is
-            // unknown when none does, so its label cannot be shared either.
+            // copy carries.  A carried definition has no target a formatted
+            // link can safely share.
             _ => {
                 // The variants live in the namespace of the shortened base, so
                 // that is what both the cursor and the reuse map are keyed by:
                 // labels long enough to be shortened to the same prefix share
                 // one namespace and must not allocate against each other.
-                let cursor_key = normalize_reference_key(truncate_reference_label_base(label));
+                let cursor_key = self.reference_key(truncate_reference_label_base(label));
                 // Reuse the variant this target was already given, if any.
                 // Looking it up directly keeps a document full of same-text
                 // links from rescanning every variant it has handed out.
@@ -663,7 +751,7 @@ impl<'a> Serializer<'a> {
                     .unwrap_or(2);
                 for n in start.. {
                     let candidate = numbered_reference_label(label, n);
-                    let candidate_key = normalize_reference_key(&candidate);
+                    let candidate_key = self.reference_key(&candidate);
                     // Copy the occupant out of the borrow so the maps below can
                     // be updated.
                     let occupant = self
@@ -682,10 +770,11 @@ impl<'a> Serializer<'a> {
                                 .or_insert(candidate);
                             continue;
                         }
-                        // Held by a definition a verbatim copy carries, whose
-                        // target is unknown; nothing to remember it by, so the
+                        // Held without a known target, either by a definition a
+                        // verbatim copy carries or by unresolved reference
+                        // syntax.  There is nothing to remember it by, so the
                         // search simply moves on.
-                        None if self.is_label_carried_verbatim(&candidate_key) => continue,
+                        None if self.is_numbered_label_unavailable(&candidate_key) => continue,
                         // Already holds this very target: share it.
                         Some(_) => {
                             self.satisfy_claimed_label(candidate_key, &candidate, url, title)
@@ -732,7 +821,7 @@ impl<'a> Serializer<'a> {
     /// earlier run had already written the very definition being reserved.
     /// Following the source keeps every run agreeing on the placement.
     pub fn reserve_reference(&mut self, label: &str, url: &str, title: &str) -> bool {
-        let key = normalize_reference_key(label);
+        let key = self.reference_key(label);
         if let Some(existing) = self.find_reference(&key)
             && (existing.url != url || existing.title != title)
         {
@@ -770,7 +859,7 @@ impl<'a> Serializer<'a> {
             if before_line.is_some_and(|line| *due >= line) {
                 return true;
             }
-            let key = normalize_reference_key(&reference.label);
+            let key = self.reference_key(&reference.label);
             if !self.emitted_references.contains_key(&key)
                 && !self.pending_references.contains_key(&key)
             {
@@ -851,7 +940,39 @@ impl<'a> Serializer<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::safe_str_slice;
+    use super::{REFERENCE_LABEL_REPLACEMENT_SCANS, Serializer, safe_str_slice};
+    use crate::Options;
+
+    #[test]
+    fn ordinary_reference_labels_skip_mdx_replacements() {
+        let options = Options::default();
+        let replacements = (0..128)
+            .map(|index| {
+                (
+                    format!("<!--hongdown-mdx:nonce:{index}-->"),
+                    format!("{{expression{index}}}"),
+                )
+            })
+            .collect();
+        let serializer = Serializer::new(&options, Vec::new(), false)
+            .with_reference_label_replacements(replacements);
+
+        REFERENCE_LABEL_REPLACEMENT_SCANS.with(|scans| scans.set(0));
+        for index in 0..128 {
+            serializer.reference_key(&format!("ordinary label {index}"));
+        }
+        REFERENCE_LABEL_REPLACEMENT_SCANS.with(|scans| assert_eq!(scans.get(), 0));
+
+        REFERENCE_LABEL_REPLACEMENT_SCANS.with(|scans| scans.set(0));
+        assert_eq!(
+            serializer.restore_reference_label(
+                "before <!--hongdown-mdx:nonce:0--> and \
+                 <!--hongdown-mdx:nonce:127--> after"
+            ),
+            "before {expression0} and {expression127} after"
+        );
+        REFERENCE_LABEL_REPLACEMENT_SCANS.with(|scans| assert_eq!(scans.get(), 2));
+    }
 
     #[test]
     fn test_safe_str_slice_ascii() {

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -3306,6 +3306,18 @@ fn test_abbreviation_with_undefined_reference() {
 }
 
 #[test]
+fn test_abbreviation_exemption_is_case_sensitive() {
+    let input = "*[HTML]: Hyper Text Markup Language\n\nSee [html].";
+    let result = parse_and_serialize_with_warnings(input);
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(result.warnings[0].line, 3);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [html]"
+    );
+}
+
+#[test]
 fn test_reference_after_abbreviation_no_warning() {
     // Reference definitions that follow abbreviation definitions (without a blank line)
     // may not be parsed by comrak as reference definitions. We should still detect

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -7153,6 +7153,48 @@ fn test_heading_undefined_reference_uses_sentence_case_rendering() {
 }
 
 #[test]
+fn test_heading_undefined_reference_uses_noun_directives() {
+    let options = Options {
+        heading_sentence_case: true,
+        ..Options::default()
+    };
+    for (directive, heading_label, link_label, emitted_label) in [
+        ("hongdown-proper-nouns: MyAPI", "MyAPI", "MyAPI", "MyAPI"),
+        (
+            "hongdown-common-nouns: Python",
+            "Python",
+            "python",
+            "python",
+        ),
+    ] {
+        let input = format!(
+            "<!-- {directive} -->\n\n\
+             # See [{heading_label} 2]\n\n\
+              -  Read [{link_label}](https://example.com/first).\n\
+              -  Read [{link_label}](https://example.com/second).\n"
+        );
+        let result = parse_and_serialize_with_warnings_and_options(&input, &options);
+        assert!(
+            result.output.contains(&format!("See [{emitted_label} 2]")),
+            "the heading should use the noun directive, got:\n{}",
+            result.output
+        );
+        assert!(
+            result
+                .output
+                .contains(&format!("[{link_label}][{link_label} 3]")),
+            "the occupied label should be skipped, got:\n{}",
+            result.output
+        );
+        assert_eq!(result.warnings.len(), 1);
+        assert_eq!(
+            result.warnings[0].message,
+            format!("undefined reference link: [{emitted_label} 2]")
+        );
+    }
+}
+
+#[test]
 fn test_numbered_link_label_skips_bang_prefixed_reference() {
     let input = "See [!guide 2].\n\n\
                   -  Read [!guide](https://example.com/first).\n\

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -61,11 +61,17 @@ fn parse_and_serialize_no_wrap(input: &str) -> String {
 }
 
 fn parse_and_serialize_with_warnings(input: &str) -> SerializeResult {
+    parse_and_serialize_with_warnings_and_options(input, &Options::default())
+}
+
+fn parse_and_serialize_with_warnings_and_options(
+    input: &str,
+    format_options: &Options,
+) -> SerializeResult {
     let arena = Arena::new();
     let options = comrak_options();
     let root = parse_document(&arena, input, &options);
-    let format_options = Options::default();
-    serialize_with_source_and_warnings(root, &format_options, Some(input))
+    serialize_with_source_and_warnings(root, format_options, Some(input))
 }
 
 #[test]
@@ -1691,6 +1697,30 @@ fn test_directive_disable_next_line_copy_carries_its_head_definition() {
     );
     assert_eq!(
         parse_and_serialize_with_source(&result),
+        result,
+        "formatting must be idempotent"
+    );
+}
+
+#[test]
+fn test_mdx_copied_block_carries_its_head_definition() {
+    let input = "<!-- hongdown-disable -->\n\n\
+                 [foo {bar}]: https://example.com/copied\n\
+                 Prose directly below keeps the definition consumed.\n\n\
+                 <!-- hongdown-enable -->\n\n\
+                 Read [foo {bar}](https://example.com/other).\n";
+    let options = Options {
+        mdx: true,
+        ..Options::default()
+    };
+    let result = crate::format(input, &options).unwrap();
+    assert!(
+        result.contains("Read [foo {bar}][foo {bar} 2].")
+            && result.contains("[foo {bar} 2]: https://example.com/other"),
+        "the formatted link must keep its own destination, got:\n{result}"
+    );
+    assert_eq!(
+        crate::format(&result, &options).unwrap(),
         result,
         "formatting must be idempotent"
     );
@@ -6331,6 +6361,971 @@ fn test_duplicate_link_text_different_urls_get_distinct_labels() {
 }
 
 #[test]
+fn test_numbered_link_label_skips_undefined_reference() {
+    let input = "See [guide 2].\n\n\
+                  -  Read [guide](https://example.com/first).\n\
+                  -  Read [guide](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert_eq!(
+        result.output,
+        concat!(
+            "See [guide 2].\n\n",
+            " -  Read [guide].\n",
+            " -  Read [guide][guide 3].\n\n",
+            "[guide]: https://example.com/first\n",
+            "[guide 3]: https://example.com/second\n",
+        )
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [guide 2]"
+    );
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert_eq!(second.warnings.len(), 1);
+    assert_eq!(
+        second.warnings[0].message,
+        "undefined reference link: [guide 2]"
+    );
+}
+
+#[test]
+fn test_numbered_link_label_preserves_emphasis_boundaries() {
+    let input = "See [_foo_ 2].\n\n\
+                  -  Read [_foo_](https://example.com/first).\n\
+                  -  Read [_foo_](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[_foo_][_foo_ 3]"),
+        "the unresolved emphasized label should remain occupied, got:\n{}",
+        result.output
+    );
+    assert!(!result.output.contains("[_foo_ 2]:"));
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [_foo_ 2]"
+    );
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+}
+
+#[test]
+fn test_whitespace_only_explicit_label_is_collapsed() {
+    let input = "See [guide 2][ ].\n\n\
+                  -  Read [guide](https://example.com/first).\n\
+                  -  Read [guide](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[guide][guide 3]"),
+        "the collapsed reference label should remain occupied, got:\n{}",
+        result.output
+    );
+    assert!(!result.output.contains("[guide 2]:"));
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [guide 2]"
+    );
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert_eq!(
+        second.warnings[0].message,
+        "undefined reference link: [guide 2]"
+    );
+}
+
+#[test]
+fn test_numbered_link_label_skips_markup_in_undefined_reference() {
+    let input = "See [foo *bar* 2].\n\n\
+                  -  Read [foo *bar*](https://example.com/first).\n\
+                  -  Read [foo *bar*](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert_eq!(
+        result.output,
+        concat!(
+            "See [foo *bar* 2].\n\n",
+            " -  Read [foo *bar*].\n",
+            " -  Read [foo *bar*][foo *bar* 3].\n\n",
+            "[foo *bar*]: https://example.com/first\n",
+            "[foo *bar* 3]: https://example.com/second\n",
+        )
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo *bar* 2]"
+    );
+}
+
+#[test]
+fn test_numbered_link_label_skips_soft_break_in_undefined_reference() {
+    let input = "See [foo\nbar 2].\n\n\
+                  -  Read [foo\nbar](https://example.com/first).\n\
+                  -  Read [foo\nbar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert_eq!(
+        result.output,
+        concat!(
+            "See [foo\nbar 2].\n\n",
+            " -  Read [foo bar].\n",
+            " -  Read [foo bar][foo bar 3].\n\n",
+            "[foo bar]: https://example.com/first\n",
+            "[foo bar 3]: https://example.com/second\n",
+        )
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo bar 2]"
+    );
+}
+
+#[test]
+fn test_numbered_link_label_skips_multiline_blockquote_reference() {
+    let input = "> See [foo\n\
+                 > bar 2].\n\n\
+                  -  Read [foo\nbar](https://example.com/first).\n\
+                  -  Read [foo\nbar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[foo bar][foo bar 3]"),
+        "blockquote prefixes must not become part of the label, got:\n{}",
+        result.output
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo bar 2]"
+    );
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert_eq!(
+        second.warnings[0].message,
+        "undefined reference link: [foo bar 2]"
+    );
+}
+
+#[test]
+fn test_lazy_blockquote_reference_preserves_literal_marker() {
+    let input = "> See [foo\n    > bar 2].\n\n\
+                  -  Read [foo > bar](https://example.com/first).\n\
+                  -  Read [foo > bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[foo > bar][foo > bar 3]"),
+        "a literal marker on a lazy continuation must remain in the label, got:\n{}",
+        result.output
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo > bar 2]"
+    );
+    assert!(!result.output.contains("[foo > bar 2]:"));
+}
+
+#[test]
+fn test_list_blockquote_reference_strips_container_indent() {
+    let input = " -  > See [foo\n    > bar 2].\n\n\
+                  -  Read [foo bar](https://example.com/first).\n\
+                  -  Read [foo bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[foo bar][foo bar 3]"),
+        "list indentation should not become part of a blockquote label, got:\n{}",
+        result.output
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo bar 2]"
+    );
+    assert!(!result.output.contains("[foo bar 2]:"));
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert_eq!(
+        second.warnings[0].message,
+        "undefined reference link: [foo bar 2]"
+    );
+}
+
+#[test]
+fn test_list_blockquote_reference_strips_tabbed_container_indent() {
+    let input = " -  > See [foo\n\
+                 \t> bar 2].\n\n\
+                  -  Read [foo bar](https://example.com/first).\n\
+                  -  Read [foo bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[foo bar][foo bar 3]"),
+        "tab indentation should not become part of a blockquote label, got:\n{}",
+        result.output
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo bar 2]"
+    );
+    assert!(!result.output.contains("[foo bar 2]:"));
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert_eq!(
+        second.warnings[0].message,
+        "undefined reference link: [foo bar 2]"
+    );
+}
+
+#[test]
+fn test_list_blockquote_lazy_reference_preserves_literal_marker() {
+    let input = " -  > See [foo\n        > bar 2].\n\n\
+                  -  Read [foo > bar](https://example.com/first).\n\
+                  -  Read [foo > bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[foo > bar][foo > bar 3]"),
+        "indentation beyond the list container should keep a literal marker, got:\n{}",
+        result.output
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo > bar 2]"
+    );
+    assert!(!result.output.contains("[foo > bar 2]:"));
+}
+
+#[test]
+fn test_numbered_link_label_skips_hard_break_in_undefined_reference() {
+    let input = "See [foo  \nbar 2].\n\n\
+                  -  Read [foo\nbar](https://example.com/first).\n\
+                  -  Read [foo\nbar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[foo bar][foo bar 3]"),
+        "the hard-break label should remain occupied, got:\n{}",
+        result.output
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo bar 2]"
+    );
+}
+
+#[test]
+fn test_undefined_reference_in_description_term() {
+    let result = parse_and_serialize_with_warnings("[missing]\n: detail\n");
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [missing]"
+    );
+}
+
+#[test]
+fn test_disabled_description_term_reserves_undefined_reference() {
+    let input = "<!-- hongdown-disable -->\n\n\
+                 [guide 2]\n\
+                 : detail\n\n\
+                 <!-- hongdown-enable -->\n\n\
+                  -  Read [guide](https://example.com/first).\n\
+                  -  Read [guide](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[guide][guide 3]"),
+        "the copied description term should reserve its label, got:\n{}",
+        result.output
+    );
+    assert!(result.warnings.is_empty());
+}
+
+#[test]
+fn test_multiline_description_term_reserves_undefined_reference() {
+    let input = "See\n\
+                 continued [guide 2]\n\
+                 : detail\n\n\
+                  -  Read [guide](https://example.com/first).\n\
+                  -  Read [guide](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[guide][guide 3]"),
+        "every line of the description term should reserve labels, got:\n{}",
+        result.output
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [guide 2]"
+    );
+}
+
+#[test]
+fn test_adjacent_inline_link_is_not_an_explicit_reference_label() {
+    let input = "See [guide 2][bar](/bar).\n\n\
+                  -  Read [guide](https://example.com/first).\n\
+                  -  Read [guide](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[guide][guide 3]"),
+        "the unresolved shortcut should reserve its own label, got:\n{}",
+        result.output
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [guide 2]"
+    );
+}
+
+#[test]
+fn test_numbered_link_label_uses_rendered_undefined_reference() {
+    let input = "See [foo_bar 2].\n\n\
+                  -  Read [foo_bar](https://example.com/first).\n\
+                  -  Read [foo_bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert_eq!(
+        result.output,
+        concat!(
+            "See [foo\\_bar 2].\n\n",
+            " -  Read [foo\\_bar].\n",
+            " -  Read [foo\\_bar][foo\\_bar 3].\n\n",
+            "[foo\\_bar]: https://example.com/first\n",
+            "[foo\\_bar 3]: https://example.com/second\n",
+        )
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo\\_bar 2]"
+    );
+}
+
+#[test]
+fn test_numbered_link_label_skips_code_in_undefined_reference() {
+    let input = "See [foo `bar` 2].\n\n\
+                  -  Read [foo `bar`](https://example.com/first).\n\
+                  -  Read [foo `bar`](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert_eq!(
+        result.output,
+        concat!(
+            "See [foo `bar` 2].\n\n",
+            " -  Read [foo `bar`].\n",
+            " -  Read [foo `bar`][foo `bar` 3].\n\n",
+            "[foo `bar`]: https://example.com/first\n",
+            "[foo `bar` 3]: https://example.com/second\n",
+        )
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo `bar` 2]"
+    );
+}
+
+#[test]
+fn test_numbered_link_label_uses_emitted_inline_spans() {
+    for (source_label, emitted_label) in [
+        ("foo -- bar", "foo — bar"),
+        ("foo &amp;", "foo &amp;"),
+        ("foo $x$", "foo $x$"),
+        ("foo <i>bar</i>", "foo <i>bar</i>"),
+    ] {
+        let input = format!(
+            "See [{source_label} 2].\n\n\
+             -  Read [{source_label}](https://example.com/first).\n\
+             -  Read [{source_label}](https://example.com/second).\n"
+        );
+        let result = parse_and_serialize_with_warnings(&input);
+        assert!(
+            result
+                .output
+                .contains(&format!("[{emitted_label}][{emitted_label} 3]")),
+            "the occupied label should be skipped for {source_label:?}, got:\n{}",
+            result.output
+        );
+        assert!(
+            !result.output.contains(&format!("[{emitted_label} 2]:")),
+            "the unresolved label should not be defined for {source_label:?}, got:\n{}",
+            result.output
+        );
+        assert_eq!(result.warnings.len(), 1);
+        assert_eq!(
+            result.warnings[0].message,
+            format!("undefined reference link: [{emitted_label} 2]")
+        );
+    }
+}
+
+#[test]
+fn test_cross_node_full_reference_warns_once_for_explicit_label() {
+    let first = parse_and_serialize_with_warnings("[foo *bar*][baz]\n");
+    assert_eq!(first.warnings.len(), 1);
+    assert_eq!(first.warnings[0].message, "undefined reference link: [baz]");
+
+    let second = parse_and_serialize_with_warnings("[foo][baz *qux*]\n");
+    assert_eq!(second.warnings.len(), 1);
+    assert_eq!(
+        second.warnings[0].message,
+        "undefined reference link: [baz *qux*]"
+    );
+}
+
+#[test]
+fn test_rendered_escaped_reference_is_not_reserved() {
+    let input = "See \\[foo_bar 2].\n\n\
+                  -  Read [foo_bar](https://example.com/first).\n\
+                  -  Read [foo_bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert_eq!(
+        result.output,
+        concat!(
+            "See \\[foo\\_bar 2].\n\n",
+            " -  Read [foo\\_bar].\n",
+            " -  Read [foo\\_bar][foo\\_bar 2].\n\n",
+            "[foo\\_bar]: https://example.com/first\n",
+            "[foo\\_bar 2]: https://example.com/second\n",
+        )
+    );
+    assert!(result.warnings.is_empty());
+}
+
+#[test]
+fn test_rendered_source_only_definition_is_not_undefined() {
+    let input = "See [foo_bar].\n\n*[X]: abbreviation\n[foo_bar]: https://example.com/\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(result.warnings.is_empty());
+}
+
+#[test]
+fn test_wrapped_source_only_reference_is_not_undefined() {
+    let input = "*[X]: abbreviation\n\
+                 [foo bar]: https://example.com/\n\n\
+                 See [foo\n\
+                 bar] here.\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.warnings.is_empty(),
+        "wrapped labels should match whitespace-normalized definitions: {:?}",
+        result.warnings
+    );
+}
+
+#[test]
+fn test_abbreviation_label_reserves_numbered_reference() {
+    let input = "See [guide 2].\n\n\
+                 *[guide 2]: abbreviation\n\n\
+                  -  Read [guide](https://example.com/first).\n\
+                  -  Read [guide](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[guide][guide 3]"),
+        "a warning-exempt abbreviation label should remain occupied, got:\n{}",
+        result.output
+    );
+    assert!(
+        !result
+            .output
+            .contains("[guide 2]: https://example.com/second")
+    );
+    assert!(result.warnings.is_empty());
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert!(second.warnings.is_empty());
+}
+
+#[test]
+fn test_verbatim_abbreviation_does_not_reserve_rendered_variant() {
+    let input = "*[foo_bar 2]: abbreviation\n\n\
+                  -  Read [foo_bar](https://example.com/first).\n\
+                  -  Read [foo_bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[foo\\_bar][foo\\_bar 2]"),
+        "the parser-distinct rendered variant should remain free, got:\n{}",
+        result.output
+    );
+    assert!(!result.output.contains("[foo\\_bar 3]:"));
+    assert!(result.output.contains("*[foo_bar 2]: abbreviation"));
+    assert!(result.warnings.is_empty());
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert!(second.warnings.is_empty());
+}
+
+#[test]
+fn test_verbatim_source_definition_does_not_reserve_rendered_variant() {
+    let input = "*[X]: abbreviation\n\
+                 [foo_bar 2]: https://example.com/existing\n\n\
+                  -  Read [foo_bar](https://example.com/first).\n\
+                  -  Read [foo_bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[foo\\_bar][foo\\_bar 2]"),
+        "the parser-distinct rendered variant should remain free, got:\n{}",
+        result.output
+    );
+    assert!(!result.output.contains("[foo\\_bar 3]:"));
+    assert!(
+        result
+            .output
+            .contains("[foo_bar 2]: https://example.com/existing")
+    );
+    assert!(result.warnings.is_empty());
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert!(second.warnings.is_empty());
+}
+
+#[test]
+fn test_prose_sharing_verbatim_label_reserves_rendered_variant() {
+    let input = "See [foo_bar 2].\n\n\
+                 *[foo_bar 2]: abbreviation\n\n\
+                  -  Read [foo_bar](https://example.com/first).\n\
+                  -  Read [foo_bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[foo\\_bar][foo\\_bar 3]"),
+        "the rendered prose occurrence should remain occupied, got:\n{}",
+        result.output
+    );
+    assert!(!result.output.contains("[foo\\_bar 2]:"));
+    assert!(result.output.contains("*[foo_bar 2]: abbreviation"));
+    assert!(result.warnings.is_empty());
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+}
+
+#[test]
+fn test_source_only_definition_label_reserves_numbered_reference() {
+    let input = "See [guide 2].\n\n\
+                 *[X]: abbreviation\n\
+                 [guide 2]: https://example.com/existing\n\n\
+                  -  Read [guide](https://example.com/first).\n\
+                  -  Read [guide](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[guide][guide 3]"),
+        "a source-only definition label should remain occupied, got:\n{}",
+        result.output
+    );
+    assert!(
+        !result
+            .output
+            .contains("[guide 2]: https://example.com/second")
+    );
+    assert!(result.warnings.is_empty());
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert!(second.warnings.is_empty());
+}
+
+#[test]
+fn test_unused_source_definition_can_supply_numbered_reference() {
+    let input = "[guide 2]: https://example.com/b\n\n\
+                  -  Read [guide](https://example.com/a).\n\
+                  -  Read [guide](https://example.com/b).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[guide][guide 2]"),
+        "the matching source label should be reused, got:\n{}",
+        result.output
+    );
+    assert!(!result.output.contains("[guide][guide 3]"));
+    assert!(result.warnings.is_empty());
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert!(second.warnings.is_empty());
+}
+
+#[test]
+fn test_code_block_definition_does_not_reserve_numbered_reference() {
+    for code_block in [
+        "~~~~ text\n[guide 2]: example\n~~~~",
+        "    [guide 2]: example",
+    ] {
+        let input = format!(
+            "{code_block}\n\n\
+             -  Read [guide](https://example.com/first).\n\
+             -  Read [guide](https://example.com/second).\n"
+        );
+        let result = parse_and_serialize_with_warnings(&input);
+        assert!(
+            result.output.contains("[guide][guide 2]"),
+            "a definition lookalike in code should leave label 2 free, got:\n{}",
+            result.output
+        );
+        assert!(!result.output.contains("[guide][guide 3]"));
+        assert!(result.warnings.is_empty());
+    }
+}
+
+#[test]
+fn test_undefined_reference_preserves_surrounding_quote_state() {
+    let input = "Opening \" then [foo\"bar 2].\n\n\
+                  -  Read [foo”bar](https://example.com/first).\n\
+                  -  Read [foo”bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("Opening “ then \\[foo”bar 2]."),
+        "the unresolved label should use the paragraph's quote state, got:\n{}",
+        result.output
+    );
+    assert!(
+        result.output.contains("[foo”bar][foo”bar 3]"),
+        "the emitted unresolved label should remain occupied, got:\n{}",
+        result.output
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo”bar 2]"
+    );
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert!(second.warnings.is_empty());
+}
+
+#[test]
+fn test_undefined_reference_preserves_resolved_link_context() {
+    let input = "[\"][ref] [foo\"bar 2].\n\n\
+                  -  Read [foo“bar](https://example.com/first).\n\
+                  -  Read [foo“bar](https://example.com/second).\n\n\
+                 [ref]: /url\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[foo“bar][foo“bar 3]"),
+        "the emitted unresolved label should remain occupied, got:\n{}",
+        result.output
+    );
+    assert!(!result.output.contains("[foo“bar 2]:"));
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo“bar 2]"
+    );
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+}
+
+#[test]
+fn test_heading_undefined_reference_preserves_resolved_link_context() {
+    let input = "# [\"][ref] [foo\"bar 2]\n\n\
+                  -  Read [foo“bar](https://example.com/first).\n\
+                  -  Read [foo“bar](https://example.com/second).\n\n\
+                 [ref]: /url\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[foo“bar][foo“bar 3]"),
+        "the emitted heading label should remain occupied, got:\n{}",
+        result.output
+    );
+    assert!(!result.output.contains("[foo“bar 2]:"));
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo“bar 2]"
+    );
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+}
+
+#[test]
+fn test_numbered_link_label_skips_escaped_closing_bracket() {
+    let input = "See [foo\\]bar 2].\n\n\
+                  -  Read [foo\\]bar](https://example.com/first).\n\
+                  -  Read [foo\\]bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert_eq!(
+        result.output,
+        concat!(
+            "See [foo\\]bar 2].\n\n",
+            " -  Read [foo\\]bar].\n",
+            " -  Read [foo\\]bar][foo\\]bar 3].\n\n",
+            "[foo\\]bar]: https://example.com/first\n",
+            "[foo\\]bar 3]: https://example.com/second\n",
+        )
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo\\]bar 2]"
+    );
+}
+
+#[test]
+fn test_undefined_reference_after_consumed_definition() {
+    let result = parse_and_serialize_with_warnings("[a]: /url\nSee [missing].\n");
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(result.warnings[0].line, 2);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [missing]"
+    );
+}
+
+#[test]
+fn test_heading_undefined_reference_uses_heading_rendering() {
+    let input = "# [foo <i>bar</i> 2]\n\n\
+                  -  Read [foo <i>bar</i>](https://example.com/first).\n\
+                  -  Read [foo <i>bar</i>](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[foo <i>bar</i>][foo <i>bar</i> 2]"),
+        "the heading's rendered label should not occupy the HTML label, got:\n{}",
+        result.output
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo bar 2]"
+    );
+}
+
+#[test]
+fn test_heading_undefined_reference_ignores_brackets_in_html() {
+    let input = "# See [foo <i title=\"]\">bar</i> 2]\n\n\
+                  -  Read [foo bar](https://example.com/first).\n\
+                  -  Read [foo bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[foo bar][foo bar 3]"),
+        "the stripped heading label should remain occupied, got:\n{}",
+        result.output
+    );
+    assert!(!result.output.contains("[foo bar 2]:"));
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo bar 2]"
+    );
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert_eq!(
+        second.warnings[0].message,
+        "undefined reference link: [foo bar 2]"
+    );
+}
+
+#[test]
+fn test_heading_undefined_reference_uses_sentence_case_rendering() {
+    let input = "# See [foo \"bar\" 2]\n\n\
+                  -  Read [foo “bar”](https://example.com/first).\n\
+                  -  Read [foo “bar”](https://example.com/second).\n";
+    let mut options = Options::default();
+    options.heading_sentence_case = true;
+    options.curly_double_quotes = false;
+
+    let result = parse_and_serialize_with_warnings_and_options(input, &options);
+    assert!(
+        result.output.contains("[foo “bar”][foo “bar” 3]"),
+        "the sentence-cased heading label should remain occupied, got:\n{}",
+        result.output
+    );
+    assert!(
+        !result.output.contains("[foo “bar” 2]:"),
+        "the unresolved heading label must not be defined, got:\n{}",
+        result.output
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo “bar” 2]"
+    );
+}
+
+#[test]
+fn test_numbered_link_label_skips_bang_prefixed_reference() {
+    let input = "See [!guide 2].\n\n\
+                  -  Read [!guide](https://example.com/first).\n\
+                  -  Read [!guide](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[!guide][!guide 3]"),
+        "the unresolved bang-prefixed label should remain occupied, got:\n{}",
+        result.output
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [!guide 2]"
+    );
+}
+
+#[test]
+fn test_numbered_link_label_skips_mdx_reference() {
+    let input = "See [foo {bar} 2].\n\n\
+                  -  Read [foo {bar}](https://example.com/first).\n\
+                  -  Read [foo {bar}](https://example.com/second).\n";
+    let options = Options {
+        mdx: true,
+        ..Options::default()
+    };
+    let result = crate::format_with_warnings(input, &options).unwrap();
+    assert!(
+        result.output.contains("[foo {bar}][foo {bar} 3]"),
+        "the restored MDX label should remain occupied, got:\n{}",
+        result.output
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo {bar} 2]"
+    );
+}
+
+#[test]
+fn test_copied_heading_reserves_verbatim_reference_label() {
+    let input = "<!-- hongdown-disable-next-line -->\n\
+                 # [foo <i>bar</i> 2]\n\n\
+                  -  Read [foo <i>bar</i>](https://example.com/first).\n\
+                  -  Read [foo <i>bar</i>](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[foo <i>bar</i>][foo <i>bar</i> 3]"),
+        "the copied heading's verbatim label should remain occupied, got:\n{}",
+        result.output
+    );
+    assert!(result.warnings.is_empty());
+}
+
+#[test]
+fn test_disabled_reference_keeps_escaped_label_free() {
+    let input = "<!-- hongdown-disable-next-line -->\n\
+                 See [foo_bar 2].\n\n\
+                  -  Read [foo_bar](https://example.com/first).\n\
+                  -  Read [foo_bar](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[foo\\_bar][foo\\_bar 2]"),
+        "parser-distinct escaped labels should remain available, got:\n{}",
+        result.output
+    );
+    assert!(result.warnings.is_empty());
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert!(second.warnings.is_empty());
+}
+
+#[test]
+fn test_bracket_in_inline_code_is_not_reference_terminator() {
+    let result = parse_and_serialize_with_warnings("See [foo `bar 2]` baz].\n");
+    assert!(
+        result.warnings.is_empty(),
+        "a bracket inside code cannot terminate a reference label: {:?}",
+        result.warnings
+    );
+}
+
+#[test]
+fn test_unresolved_reference_inside_link_text_remains_occupied() {
+    let input = "[x [guide 2]](/u)\n\n\
+                  -  Read [guide](https://example.com/first).\n\
+                  -  Read [guide](https://example.com/second).\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert!(
+        result.output.contains("[x [guide 2]](/u)"),
+        "the outer link should retain its destination, got:\n{}",
+        result.output
+    );
+    assert!(
+        result.output.contains("[guide][guide 3]"),
+        "the nested unresolved label should remain occupied, got:\n{}",
+        result.output
+    );
+    assert!(!result.output.contains("[guide 2]:"));
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [guide 2]"
+    );
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert_eq!(
+        second.warnings[0].message,
+        "undefined reference link: [guide 2]"
+    );
+}
+
+#[test]
+fn test_heading_reference_marker_does_not_collide_with_source() {
+    let input = format!(
+        "# {} [foo 2]\n\n\
+         -  Read [foo](https://example.com/first).\n\
+         -  Read [foo](https://example.com/second).\n",
+        '\u{e000}'
+    );
+    let result = parse_and_serialize_with_warnings(&input);
+    assert!(
+        result.output.contains("[foo][foo 3]"),
+        "a source PUA character must not corrupt the occupied label, got:\n{}",
+        result.output
+    );
+    assert_eq!(result.warnings.len(), 1);
+    assert_eq!(
+        result.warnings[0].message,
+        "undefined reference link: [foo 2]"
+    );
+}
+
+#[test]
+fn test_numbered_link_label_uses_complete_container_source() {
+    let escaped = "\\\\[guide 2]\n\n\
+                   -  Read [guide](https://example.com/first).\n\
+                   -  Read [guide](https://example.com/second).\n";
+    let escaped_result = parse_and_serialize_with_warnings(escaped);
+    assert!(
+        escaped_result.output.contains("[guide][guide 3]"),
+        "both source backslashes must be reconstructed, got:\n{}",
+        escaped_result.output
+    );
+    assert_eq!(escaped_result.warnings.len(), 1);
+    assert_eq!(
+        escaped_result.warnings[0].message,
+        "undefined reference link: [guide 2]"
+    );
+
+    let table = "| Value |\n\
+                 | ----- |\n\
+                 | [foo\\|bar 2] |\n\n\
+                  -  Read [foo\\|bar](https://example.com/first).\n\
+                  -  Read [foo\\|bar](https://example.com/second).\n";
+    let table_result = parse_and_serialize_with_warnings(table);
+    assert!(
+        table_result.output.contains("[foo\\|bar][foo\\|bar 3]"),
+        "the complete table-cell label must remain occupied, got:\n{}",
+        table_result.output
+    );
+}
+
+#[test]
+fn test_undefined_reference_scan_handles_many_inline_spans() {
+    let input = "[missing] *markup* ".repeat(1_000);
+    let result = parse_and_serialize_with_warnings(&input);
+    assert_eq!(result.warnings.len(), 1_000);
+}
+
+#[test]
 fn test_duplicate_link_text_same_url_reuses_label() {
     // Identical targets should still share a single definition.
     let input = " -  Read [guide](https://example.com/).\n \
@@ -6347,6 +7342,19 @@ fn test_duplicate_link_text_same_url_reuses_label() {
         "identical targets should not be renamed, got:\n{}",
         result
     );
+}
+
+#[test]
+fn test_escaped_and_unescaped_reference_labels_remain_distinct() {
+    let input = "[one][foo_bar] and [two][foo\\_bar].\n\n\
+                 [foo_bar]: https://example.com/\n\
+                 [foo\\_bar]: https://example.com/\n";
+    let result = parse_and_serialize_with_warnings(input);
+    assert_eq!(result.output, input);
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert!(second.warnings.is_empty());
 }
 
 #[test]

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -516,8 +516,16 @@ pub fn format_with_code_formatter(
         }) as Box<dyn Fn(&str, &str) -> Option<String>>
     });
 
-    let result =
-        crate::serializer::serialize_with_code_formatter(root, &opts, Some(source), callback);
+    let replacements = protection
+        .as_ref()
+        .map_or_else(Vec::new, |p| p.reference_label_replacements());
+    let result = crate::serializer::serialize_with_code_formatter(
+        root,
+        &opts,
+        Some(source),
+        callback,
+        replacements,
+    );
 
     let output = match &protection {
         Some(p) => p.restore(&result.output),
@@ -534,7 +542,9 @@ pub fn format_with_code_formatter(
                 line: protection
                     .as_ref()
                     .map_or(w.line, |p| p.original_line(w.line)),
-                message: w.message,
+                message: protection
+                    .as_ref()
+                    .map_or(w.message.clone(), |p| p.restore(&w.message)),
             })
             .collect(),
     };

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -457,7 +457,7 @@ pub fn format_with_code_formatter(
     options: JsValue,
     code_formatter: Option<js_sys::Function>,
 ) -> Result<JsValue, JsError> {
-    use comrak::{Arena, Options as ComrakOptions, parse_document};
+    use comrak::{Arena, parse_document};
 
     let js_opts: JsOptions = if options.is_undefined() || options.is_null() {
         JsOptions::default()
@@ -476,14 +476,7 @@ pub fn format_with_code_formatter(
     }
 
     let arena = Arena::new();
-    let mut comrak_options = ComrakOptions::default();
-    comrak_options.extension.front_matter_delimiter = Some("---".to_string());
-    comrak_options.extension.table = true;
-    comrak_options.extension.description_lists = true;
-    comrak_options.extension.alerts = true;
-    comrak_options.extension.footnotes = true;
-    comrak_options.extension.tasklist = true;
-    comrak_options.extension.math_dollars = opts.math;
+    let comrak_options = crate::comrak_options(&opts);
 
     // In MDX mode, protect embedded JavaScript/JSX before parsing and restore it
     // afterwards (see [`crate::mdx`]).


### PR DESCRIPTION
A reference definition has document-wide scope, so Hongdown's numbered-label fallback can change meaning instead of merely choosing a different spelling. If `[guide]` is already tied to one destination, assigning `[guide 2]` to a second link also defines any unresolved `[guide 2]` that already appears as ordinary text elsewhere in the document. Hongdown could therefore warn that the text was unresolved and then make it a link in the same formatting pass. A second pass would no longer warn because the generated definition had made the reference valid, hiding the semantic change on subsequent runs.

The bug was introduced with the still-unreleased numbered-label allocator from #29, and #32 adds another path that can force a formatted link onto a numbered variant. Fixing the allocator before release keeps documents that were safe in version 0.5.1 from acquiring links solely because they were passed through the formatter.

This pull request prevents that transition by treating unresolved reference syntax as an existing claim on the label namespace. Before link definitions are allocated, *src/serializer/document.rs* reconstructs unresolved labels from their complete inline containers and reserves the spelling that Hongdown will actually emit. Rendering in context is necessary because Comrak can split a label across inline nodes, while escapes, punctuation conversion, heading sentence case, stripped heading HTML, soft and hard breaks, blockquote prefixes, and copied regions can all make the emitted label differ from a raw AST text node or source slice.

Reservation is deliberately separate from warning policy. A label may be exempt from an undefined-reference warning because it appears in copied source, an abbreviation, or a source-only definition, yet it can still occupy the parser's label namespace. Conversely, bracket-like text inside code and other opaque blocks cannot become a reference and must not force unnecessary renumbering. *src/serializer/state.rs* now consults the reserved unresolved-label set while retaining the existing rules for same-target reuse, parser-distinct escaped labels, and the CommonMark label length limit.

MDX needs the same decision to be made on restored source text rather than Hongdown's internal protection tokens. The replacement map from *src/mdx.rs* is therefore threaded through the ordinary formatting, warning, and callback-based WASM serializer paths, and labels are restored before their lookup keys are normalized. This keeps both allocation and diagnostics consistent across the Rust API and `formatWithCodeFormatter`.

The scanner works from indexed source lines and batches context-sensitive rendering instead of reparsing once per reference. Those constraints matter because undefined-reference analysis runs during normal formatting, including on large documents and documents with many headings, inline spans, copied regions, or opaque blocks.

Regression coverage in *src/serializer/tests.rs* exercises plain, cross-node, escaped, multiline, nested-container, heading, copied-region, MDX, and adversarial inputs, including second-pass idempotence and performance bounds. *packages/wasm/test/index.test.ts* covers the callback serializer's MDX path. *STYLE.md* documents that unresolved reference labels occupy the allocator namespace, and *CHANGES.md* records the user-visible fix.

Closes #33.