### PR TITLE
Preserve non-ASCII edge whitespace in link labels

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Version 0.5.2
 
 To be released.
 
+ -  Fixed a bug where non-ASCII whitespace at the edge of an inline link's text
+    could leave its generated shortcut reference with no matching definition.
+    Reference labels now follow the parser's edge-whitespace rules, preserving
+    distinct labels and their definitions across formatting runs.
+    [[#31], [#35]]
+
  -  Fixed a bug where formatting could silently change a link's destination.
     Reference labels are generated from the link text, so two links with the
     same text but different destinations were given the same label, and the
@@ -80,9 +86,11 @@ To be released.
 [#26]: https://github.com/dahlia/hongdown/issues/26
 [#27]: https://github.com/dahlia/hongdown/issues/27
 [#29]: https://github.com/dahlia/hongdown/pull/29
+[#31]: https://github.com/dahlia/hongdown/issues/31
 [#32]: https://github.com/dahlia/hongdown/pull/32
 [#33]: https://github.com/dahlia/hongdown/issues/33
 [#34]: https://github.com/dahlia/hongdown/pull/34
+[#35]: https://github.com/dahlia/hongdown/pull/35
 
 
 Version 0.5.1

--- a/STYLE.md
+++ b/STYLE.md
@@ -426,10 +426,17 @@ numbered label and full reference syntax:
 [guide 2]: https://example.com/second
 ~~~~
 
-Labels are compared the way CommonMark resolves them: with runs of whitespace
-collapsed and Unicode case folding applied.  So `[Guide]` and `[guide]` are
-the same label, as are `[Straße]` and `[STRASSE]`, and one of them is
-renumbered unless both point at the same target.
+Labels are compared the way CommonMark resolves them: CommonMark ASCII
+whitespace is trimmed from the edges, remaining whitespace runs are collapsed,
+and Unicode case folding is applied.  So `[Guide]` and `[guide]` are the same
+label, as are `[Straße]` and `[STRASSE]`, and one of them is renumbered unless
+both point at the same target.  Non-ASCII whitespace at a label edge remains
+significant.
+
+When an inline external link is converted to reference style, its displayed
+text is preserved while the generated label is normalized separately.
+Significant edge whitespace is retained in both so that the reference resolves
+through the same key.
 
 For numbered label allocation, a label appearing as unresolved reference
 syntax is also considered occupied.  Allocation skips it rather than adding a

--- a/src/serializer/escape.rs
+++ b/src/serializer/escape.rs
@@ -1,8 +1,65 @@
 //! Text escaping and formatting utilities for Markdown serialization.
 
-/// Normalize whitespace in text: convert newlines and multiple spaces to single space.
-pub fn normalize_whitespace(text: &str) -> String {
-    text.split_whitespace().collect::<Vec<_>>().join(" ")
+/// Return whether `ch` is whitespace trimmed from a CommonMark label edge.
+pub(super) fn is_commonmark_whitespace(ch: char) -> bool {
+    matches!(ch, ' ' | '\t' | '\n' | '\r')
+}
+
+/// Normalize a reference label's emitted spelling without losing significant
+/// whitespace at its edges.
+///
+/// CommonMark trims its own ASCII whitespace from label edges, but converts
+/// other Unicode whitespace there to an ordinary space in the lookup key.
+/// Keeping one original non-CommonMark whitespace character at either edge
+/// ensures the emitted spelling produces that key when parsed again.
+pub(super) fn normalize_reference_spelling(text: &str) -> String {
+    let chars: Vec<char> = text
+        .chars()
+        .map(|ch| if ch == '\x00' { ' ' } else { ch })
+        .collect();
+    let Some(first) = chars.iter().position(|ch| !ch.is_whitespace()) else {
+        return chars
+            .into_iter()
+            .find(|ch| !is_commonmark_whitespace(*ch))
+            .map(String::from)
+            .unwrap_or_default();
+    };
+    let last = chars
+        .iter()
+        .rposition(|ch| !ch.is_whitespace())
+        .expect("a first non-whitespace character implies a last one");
+    let mut normalized = String::with_capacity(text.len());
+
+    if let Some(ch) = chars[..first]
+        .iter()
+        .copied()
+        .find(|ch| !is_commonmark_whitespace(*ch))
+    {
+        normalized.push(ch);
+    }
+
+    let mut last_was_whitespace = false;
+    for &ch in &chars[first..=last] {
+        if ch.is_whitespace() {
+            if !last_was_whitespace {
+                normalized.push(' ');
+                last_was_whitespace = true;
+            }
+        } else {
+            normalized.push(ch);
+            last_was_whitespace = false;
+        }
+    }
+
+    if let Some(ch) = chars[last + 1..]
+        .iter()
+        .copied()
+        .find(|ch| !is_commonmark_whitespace(*ch))
+    {
+        normalized.push(ch);
+    }
+
+    normalized
 }
 
 /// Escape special Markdown characters in text content.
@@ -196,6 +253,18 @@ pub fn escape_table_cell(content: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_normalize_reference_spelling() {
+        assert_eq!(normalize_reference_spelling(" \tfoo\r\n"), "foo");
+        assert_eq!(
+            normalize_reference_spelling(" \u{a0}foo\u{2003}\t"),
+            "\u{a0}foo\u{2003}"
+        );
+        assert_eq!(normalize_reference_spelling("foo\u{a0}\tbar"), "foo bar");
+        assert_eq!(normalize_reference_spelling("\u{a0}\u{2003}"), "\u{a0}");
+        assert_eq!(normalize_reference_spelling(" \t\r\n"), "");
+    }
 
     #[test]
     fn test_is_valid_code_span() {

--- a/src/serializer/inline.rs
+++ b/src/serializer/inline.rs
@@ -14,6 +14,16 @@ impl<'a> Serializer<'a> {
         text
     }
 
+    /// Serialize the inline children of `node` without adding an outer link or
+    /// image wrapper.
+    pub(super) fn collect_inline_children<'b>(&mut self, node: &'b AstNode<'b>) -> String {
+        let mut text = String::new();
+        for child in node.children() {
+            self.collect_inline_node(child, &mut text);
+        }
+        text
+    }
+
     /// Collect raw text without escaping (for comparison purposes)
     pub(super) fn collect_raw_text<'b>(&self, node: &'b AstNode<'b>) -> String {
         let mut text = String::new();
@@ -107,13 +117,14 @@ impl<'a> Serializer<'a> {
             }
             NodeValue::Link(link) => {
                 // Handle reference-style links in headings
-                if let Some((link_text, label)) = self.get_reference_style_info(node) {
+                if let Some((_, label)) = self.get_reference_style_info(node) {
+                    let link_text = self.collect_inline_children(node);
                     self.format_reference_link(text, &link_text, &label, &link.url, &link.title);
                 } else {
                     // For inline links, just output plain text (or format as inline?)
                     // In headings, we typically want reference style for external links
-                    let link_text = self.collect_raw_text(node);
                     if Self::is_external_url(&link.url) {
+                        let link_text = self.collect_inline_children(node);
                         // Headings don't have footnote references as siblings, so no need for collapsed style
                         self.format_external_link_as_reference(
                             text,
@@ -123,6 +134,7 @@ impl<'a> Serializer<'a> {
                             false,
                         );
                     } else {
+                        let link_text = self.collect_raw_text(node);
                         Self::format_inline_link(text, &link_text, &link.url, &link.title);
                     }
                 }
@@ -227,7 +239,7 @@ impl<'a> Serializer<'a> {
                 let is_autolink = link.title.is_empty() && raw_text == link.url;
 
                 // Check if original was reference style
-                if let Some((text, label)) = self.get_reference_style_info(node) {
+                if let Some((_, label)) = self.get_reference_style_info(node) {
                     // Preserve reference style
                     if contains_image {
                         // Badge-style with reference: [![alt][img-ref]][link-ref]
@@ -243,6 +255,7 @@ impl<'a> Serializer<'a> {
                         content.push(']');
                     } else {
                         // Non-badge reference links: use helper
+                        let text = self.collect_inline_children(node);
                         self.format_reference_link(content, &text, &label, &link.url, &link.title);
                     }
                 } else if contains_image {
@@ -264,10 +277,7 @@ impl<'a> Serializer<'a> {
                     Self::format_autolink(content, &link.url);
                 } else if Self::is_external_url(&link.url) {
                     // External URL: collect link text first
-                    let mut link_text = String::new();
-                    for child in node.children() {
-                        self.collect_inline_node(child, &mut link_text);
-                    }
+                    let link_text = self.collect_inline_children(node);
                     // Check if next sibling starts with '[' to decide if we need collapsed style
                     let use_collapsed = Self::next_sibling_starts_with_bracket(node);
                     self.format_external_link_as_reference(
@@ -279,10 +289,7 @@ impl<'a> Serializer<'a> {
                     );
                 } else {
                     // Relative/local URL: keep as inline link
-                    let mut link_text = String::new();
-                    for child in node.children() {
-                        self.collect_inline_node(child, &mut link_text);
-                    }
+                    let link_text = self.collect_inline_children(node);
                     Self::format_inline_link(content, &link_text, &link.url, &link.title);
                 }
             }

--- a/src/serializer/link.rs
+++ b/src/serializer/link.rs
@@ -16,13 +16,14 @@ impl<'a> Serializer<'a> {
     ) {
         let collapsed = label.starts_with('\x01');
         let label = label.strip_prefix('\x01').unwrap_or(label);
+        let emitted_text = text.replace('\x00', " ");
         // The label may already be taken by a different target, in which case a
         // distinct one is allocated and the full reference form is required.
         let label = self.register_reference(label, url, title);
 
         output.push('[');
-        output.push_str(text);
-        if label == text {
+        output.push_str(&emitted_text);
+        if label == emitted_text {
             if collapsed {
                 // Collapsed reference: [text][]
                 output.push_str("][]");
@@ -72,15 +73,17 @@ impl<'a> Serializer<'a> {
         title: &str,
         use_collapsed: bool,
     ) {
-        // Normalize: replace SoftBreak markers with spaces for shortcut refs
-        let normalized_text = text.replace('\x00', " ");
+        let emitted_text = text.replace('\x00', " ");
+        // Normalize the label separately so whitespace-sensitive inline
+        // content remains unchanged in the displayed link text.
+        let normalized_label = super::escape::normalize_reference_spelling(&emitted_text);
         // The link text is only usable as the label when it is not already
         // taken by a different target; otherwise fall back to a full reference.
-        let label = self.register_reference(&normalized_text, url, title);
+        let label = self.register_reference(&normalized_label, url, title);
 
         output.push('[');
-        output.push_str(&normalized_text);
-        if label == normalized_text {
+        output.push_str(&emitted_text);
+        if label == emitted_text {
             output.push(']');
             if use_collapsed {
                 output.push_str("[]");
@@ -162,7 +165,7 @@ impl<'a> Serializer<'a> {
         let is_autolink = title.is_empty() && raw_text == url;
 
         // Check if original was reference style
-        if let Some((text, label)) = self.get_reference_style_info(node) {
+        if let Some((_, label)) = self.get_reference_style_info(node) {
             // For badge-style, serialize children first to get image content
             if contains_image {
                 // Badge-style with reference: [![alt][img-ref]][link-ref]
@@ -177,6 +180,7 @@ impl<'a> Serializer<'a> {
                 self.output.push(']');
             } else {
                 // Use helper for non-badge reference links
+                let text = self.collect_inline_children(node);
                 let mut output = String::new();
                 self.format_reference_link(&mut output, &text, &label, url, title);
                 self.output.push_str(&output);
@@ -198,7 +202,7 @@ impl<'a> Serializer<'a> {
         } else if is_autolink {
             Self::format_autolink(&mut self.output, url);
         } else if Self::is_external_url(url) {
-            let link_text = self.collect_text(node);
+            let link_text = self.collect_inline_children(node);
             let mut output = String::new();
             let use_collapsed = Self::next_sibling_starts_with_bracket(node);
             self.format_external_link_as_reference(

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -197,8 +197,8 @@ impl<'a> Serializer<'a> {
         let after_close: String = chars[text_end_pos + 1..].iter().collect();
         let text: String = chars[first_bracket + 1..text_end_pos].iter().collect();
 
-        // Normalize newlines to spaces in the text (for idempotency when text spans lines)
-        let text = escape::normalize_whitespace(&text);
+        // Normalize the reference spelling for idempotency across formatting runs.
+        let text = escape::normalize_reference_spelling(&text);
 
         // If followed by "(", it's inline style
         if after_close.starts_with('(') {
@@ -211,7 +211,7 @@ impl<'a> Serializer<'a> {
             if let Some(label_end) = find_unescaped(label_content, ']') {
                 let label = label_content[..label_end].to_string();
                 // Normalize label too
-                let label = escape::normalize_whitespace(&label);
+                let label = escape::normalize_reference_spelling(&label);
 
                 // If label is empty, it's collapsed reference - mark with special prefix
                 // to distinguish from shortcut reference

--- a/src/serializer/state.rs
+++ b/src/serializer/state.rs
@@ -122,16 +122,32 @@ const MDX_REFERENCE_LABEL_TOKEN_PREFIX: &str = "<!--hongdown-mdx:";
 /// and applying Unicode default case folding, so labels that differ only in
 /// spacing or case refer to the same definition and must share a single key.
 /// This mirrors comrak's `normalize_label(_, Case::Fold)`, down to using the
-/// same case folding implementation: plain lowercasing would miss pairs such
-/// as `Straße` and `STRASSE`.  Internal wrapping markers are normalized to
-/// their emitted form: a SoftBreak becomes a space, while math sentinels
-/// disappear.  Backslashes remain significant because comrak keeps them in
-/// reference-label lookup keys.
+/// same edge-whitespace and case-folding rules: only CommonMark's ASCII
+/// whitespace is trimmed from the edges, while every Unicode whitespace run
+/// that remains is collapsed to a single space.  Plain lowercasing would miss
+/// pairs such as `Straße` and `STRASSE`.  Internal wrapping markers are
+/// normalized to their emitted form: a SoftBreak becomes a space, while math
+/// sentinels disappear.  Backslashes remain significant because comrak keeps
+/// them in reference-label lookup keys.
 pub fn normalize_reference_key(label: &str) -> String {
     let emitted = label
         .replace('\x00', " ")
         .replace([super::MATH_TOKEN_OPEN, super::MATH_TOKEN_CLOSE], "");
-    caseless::default_case_fold_str(&super::escape::normalize_whitespace(&emitted))
+    let trimmed = emitted.trim_matches(super::escape::is_commonmark_whitespace);
+    let mut normalized = String::with_capacity(trimmed.len());
+    let mut last_was_whitespace = false;
+    for ch in trimmed.chars() {
+        if ch.is_whitespace() {
+            if !last_was_whitespace {
+                normalized.push(' ');
+                last_was_whitespace = true;
+            }
+        } else {
+            normalized.push(ch);
+            last_was_whitespace = false;
+        }
+    }
+    caseless::default_case_fold_str(&normalized)
 }
 
 /// The longest suffix [`numbered_reference_label`] appends, in bytes: a space
@@ -161,7 +177,10 @@ fn truncate_reference_label_base(label: &str) -> &str {
 
 /// Build the `n`th numbered variant of `label`, such as `guide 2`.
 fn numbered_reference_label(label: &str, n: u32) -> String {
-    format!("{} {n}", truncate_reference_label_base(label))
+    super::escape::normalize_reference_spelling(&format!(
+        "{} {n}",
+        truncate_reference_label_base(label)
+    ))
 }
 
 /// A footnote definition: name -> content
@@ -940,8 +959,17 @@ impl<'a> Serializer<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::{REFERENCE_LABEL_REPLACEMENT_SCANS, Serializer, safe_str_slice};
+    use super::{
+        REFERENCE_LABEL_REPLACEMENT_SCANS, Serializer, normalize_reference_key, safe_str_slice,
+    };
     use crate::Options;
+
+    #[test]
+    fn reference_key_matches_comrak_edge_whitespace() {
+        assert_eq!(normalize_reference_key(" \tfoo\r\n"), "foo");
+        assert_eq!(normalize_reference_key("\u{a0}foo"), " foo");
+        assert_eq!(normalize_reference_key("foo\u{a0}"), "foo ");
+    }
 
     #[test]
     fn ordinary_reference_labels_skip_mdx_replacements() {

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -7399,6 +7399,91 @@ fn test_duplicate_link_text_same_url_reuses_label() {
 }
 
 #[test]
+fn test_non_ascii_edge_whitespace_keeps_reference_labels_distinct() {
+    // Comrak trims only CommonMark ASCII whitespace from reference-label
+    // edges, so a no-break space must remain in both the emitted link and its
+    // definition.
+    // https://github.com/dahlia/hongdown/issues/31
+    for text in ["\u{a0}foo", "foo\u{a0}"] {
+        let input = format!(
+            "See [foo](https://example.com/x) and \
+             [{text}](https://example.com/y) too.\n"
+        );
+        let expected = format!(
+            "See [foo] and [{text}] too.\n\n\
+             [foo]: https://example.com/x\n\
+             [{text}]: https://example.com/y\n"
+        );
+        let result = parse_and_serialize_with_warnings(&input);
+        assert_eq!(result.output, expected, "failed for {text:?}");
+        assert!(result.warnings.is_empty());
+
+        let second = parse_and_serialize_with_warnings(&result.output);
+        assert_eq!(second.output, result.output);
+        assert!(second.warnings.is_empty());
+    }
+}
+
+#[test]
+fn test_numbered_label_after_non_ascii_edge_whitespace_is_idempotent() {
+    let input = "See [foo\u{a0}](https://example.com/x) and \
+                 [foo\u{a0}](https://example.com/y) too.\n";
+    let expected = "See [foo\u{a0}] and [foo\u{a0}][foo 2] too.\n\n\
+                    [foo\u{a0}]: https://example.com/x\n\
+                    [foo 2]: https://example.com/y\n";
+
+    let result = parse_and_serialize_with_warnings(input);
+    assert_eq!(result.output, expected);
+    assert!(result.warnings.is_empty());
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert!(second.warnings.is_empty());
+}
+
+#[test]
+fn test_generated_label_normalization_preserves_link_content() {
+    for (text, label) in [(" foo ", "foo"), ("`a  b`", "`a b`")] {
+        let input = format!("See [{text}](https://example.com/).\n");
+        let expected = format!(
+            "See [{text}][{label}].\n\n\
+             [{label}]: https://example.com/\n"
+        );
+
+        let result = parse_and_serialize_with_warnings(&input);
+        assert_eq!(result.output, expected, "failed for {text:?}");
+        assert!(result.warnings.is_empty());
+
+        let second = parse_and_serialize_with_warnings(&result.output);
+        assert_eq!(second.output, result.output);
+        assert!(second.warnings.is_empty());
+    }
+}
+
+#[test]
+fn test_non_ascii_edge_whitespace_preserves_inline_span_spaces() {
+    for (text, label) in [
+        ("`a  b`", "`a b`"),
+        ("$a  b$", "$a b$"),
+        ("<span>a  b</span>", "<span>a b</span>"),
+    ] {
+        let input = format!("See [\u{a0}{text}](https://example.com/).\n");
+        let expected = format!(
+            "See [\u{a0}{text}][\u{a0}{label}].\n\n\
+             [\u{a0}{label}]: https://example.com/\n"
+        );
+
+        let result = parse_and_serialize_with_warnings(&input);
+        assert_eq!(result.output, expected, "failed for {text:?}");
+        assert!(result.warnings.is_empty());
+
+        let second = parse_and_serialize_with_warnings(&result.output);
+        assert_eq!(second.output, result.output);
+        assert!(second.warnings.is_empty());
+    }
+}
+
+#[test]
 fn test_escaped_and_unescaped_reference_labels_remain_distinct() {
     let input = "[one][foo_bar] and [two][foo\\_bar].\n\n\
                  [foo_bar]: https://example.com/\n\


### PR DESCRIPTION
Closes #31.


Why the labels diverged
-----------------------

Hongdown used Rust's broad Unicode whitespace handling when deriving reference keys.  Comrak follows CommonMark more narrowly: it trims spaces, tabs, carriage returns, and line feeds at the edges, but a no-break space remains significant. Treating those rules as interchangeable could emit a shortcut link whose definition Comrak stored under another key.  A second formatting pass could then reinterpret or rewrite the link.


How normalization works
-----------------------

The serializer mirrors Comrak at two layers.  Lookup keys trim only CommonMark edge whitespace, then collapse the remaining whitespace runs and apply Unicode case folding.  Emitted label spellings keep significant non-ASCII whitespace at each edge, so reparsing yields the same key.

Visible link content and reference labels are serialized separately.  This allows a label to normalize whitespace without changing spaces inside code spans, math, or inline HTML.  Numbered labels go through the same spelling normalizer after suffix allocation, which prevents a trailing non-ASCII space from forming a different label on the next run.

The shared rules live in *src/serializer/escape.rs* and *src/serializer/state.rs*.  The paths through *src/serializer/inline.rs* and *src/serializer/link.rs* keep display serialization separate from label generation.  *STYLE.md* records the distinction so the documented format matches the parser's behavior.


How it was verified
-------------------

The regression tests use distinct URLs so a label collision cannot hide behind identical targets.  They cover leading and trailing no-break spaces, numbered collisions, ASCII edge spaces, and whitespace-sensitive inline constructs. Each case formats the result again and requires the second output to be byte-for-byte identical.

`mise run test` and `mise run check` both pass.
