### PR TITLE
Normalize external inline link whitespace in one pass

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Version 0.5.2
 
 To be released.
 
+ -  Fixed a bug where an external inline link whose text contained consecutive
+    whitespace could require two formatting passes to settle.  Runs of
+    CommonMark ASCII whitespace in ordinary link text are now collapsed on the
+    first pass, so `[a  b](https://example.com/)` immediately becomes `[a b]`
+    with a matching definition.  [[#28], [#36]]
+
  -  Fixed a bug where non-ASCII whitespace at the edge of an inline link's text
     could leave its generated shortcut reference with no matching definition.
     Reference labels now follow the parser's edge-whitespace rules, preserving
@@ -85,12 +91,14 @@ To be released.
 
 [#26]: https://github.com/dahlia/hongdown/issues/26
 [#27]: https://github.com/dahlia/hongdown/issues/27
+[#28]: https://github.com/dahlia/hongdown/issues/28
 [#29]: https://github.com/dahlia/hongdown/pull/29
 [#31]: https://github.com/dahlia/hongdown/issues/31
 [#32]: https://github.com/dahlia/hongdown/pull/32
 [#33]: https://github.com/dahlia/hongdown/issues/33
 [#34]: https://github.com/dahlia/hongdown/pull/34
 [#35]: https://github.com/dahlia/hongdown/pull/35
+[#36]: https://github.com/dahlia/hongdown/pull/36
 
 
 Version 0.5.1

--- a/STYLE.md
+++ b/STYLE.md
@@ -433,10 +433,12 @@ label, as are `[Straße]` and `[STRASSE]`, and one of them is renumbered unless
 both point at the same target.  Non-ASCII whitespace at a label edge remains
 significant.
 
-When an inline external link is converted to reference style, its displayed
-text is preserved while the generated label is normalized separately.
-Significant edge whitespace is retained in both so that the reference resolves
-through the same key.
+When an inline external link is converted to reference style, runs of CommonMark
+ASCII whitespace in ordinary text are collapsed to one space before its
+displayed text and label are emitted.  Whitespace-sensitive inline constructs,
+including code spans, math, and inline HTML, keep their displayed content; their
+generated labels are normalized separately.  Significant edge whitespace is
+retained in both so that the reference resolves through the same key.
 
 For numbered label allocation, a label appearing as unresolved reference
 syntax is also considered occupied.  Allocation skips it rather than adding a

--- a/STYLE.md
+++ b/STYLE.md
@@ -363,6 +363,20 @@ Read the [installation guide] before proceeding.
 out of the text flow.  Placing definitions at section end keeps related content
 together.
 
+### Inline style for links containing images
+
+Keep an inline link inline when its text contains an image, even if its
+destination is external.  This includes images nested inside emphasis or strong
+spans:
+
+~~~~ markdown
+[**![Build status](https://example.com/status.svg)**](https://example.com/build)
+~~~~
+
+*Rationale*: Image syntax contains brackets, which are not allowed in a
+reference label.  Turning the complete link text into a label would produce an
+invalid reference and leave the outer link unresolved.
+
 ### Inline style for relative URLs
 
 Keep relative URLs and fragment links inline:

--- a/src/serializer/inline.rs
+++ b/src/serializer/inline.rs
@@ -109,7 +109,6 @@ impl<'a> Serializer<'a> {
     fn normalize_link_text_segments(segments: Vec<LinkTextSegment>) -> String {
         let mut output = String::new();
         let mut pending_whitespace = String::new();
-        let mut has_content = false;
 
         for segment in segments {
             match segment {
@@ -118,47 +117,29 @@ impl<'a> Serializer<'a> {
                         if escape::is_commonmark_whitespace(ch) {
                             pending_whitespace.push(ch);
                         } else {
-                            Self::flush_link_text_whitespace(
-                                &mut output,
-                                &mut pending_whitespace,
-                                has_content,
-                            );
+                            Self::flush_link_text_whitespace(&mut output, &mut pending_whitespace);
                             output.push(ch);
-                            has_content = true;
                         }
                     }
                 }
                 LinkTextSegment::Verbatim(text) => {
                     if !text.is_empty() {
-                        Self::flush_link_text_whitespace(
-                            &mut output,
-                            &mut pending_whitespace,
-                            has_content,
-                        );
+                        Self::flush_link_text_whitespace(&mut output, &mut pending_whitespace);
                         output.push_str(&text);
-                        has_content = true;
                     }
                 }
             }
         }
 
-        output.push_str(&pending_whitespace);
+        Self::flush_link_text_whitespace(&mut output, &mut pending_whitespace);
         output
     }
 
-    fn flush_link_text_whitespace(
-        output: &mut String,
-        pending_whitespace: &mut String,
-        has_content: bool,
-    ) {
+    fn flush_link_text_whitespace(output: &mut String, pending_whitespace: &mut String) {
         if pending_whitespace.is_empty() {
             return;
         }
-        if has_content {
-            output.push(' ');
-        } else {
-            output.push_str(pending_whitespace);
-        }
+        output.push(' ');
         pending_whitespace.clear();
     }
 

--- a/src/serializer/inline.rs
+++ b/src/serializer/inline.rs
@@ -7,6 +7,11 @@ use super::escape;
 use super::punctuation;
 use super::{MATH_TOKEN_CLOSE, MATH_TOKEN_OPEN};
 
+enum LinkTextSegment {
+    Ordinary(String),
+    Verbatim(String),
+}
+
 impl<'a> Serializer<'a> {
     pub(super) fn collect_text<'b>(&mut self, node: &'b AstNode<'b>) -> String {
         let mut text = String::new();
@@ -22,6 +27,181 @@ impl<'a> Serializer<'a> {
             self.collect_inline_node(child, &mut text);
         }
         text
+    }
+
+    pub(super) fn contains_image<'b>(node: &'b AstNode<'b>) -> bool {
+        node.children().any(|child| {
+            matches!(&child.data.borrow().value, NodeValue::Image(_)) || Self::contains_image(child)
+        })
+    }
+
+    /// Serialize inline children while collapsing whitespace runs in ordinary
+    /// text nodes.  Whitespace-sensitive inline constructs remain untouched.
+    pub(super) fn collect_normalized_link_text<'b>(&mut self, node: &'b AstNode<'b>) -> String {
+        let mut segments = Vec::new();
+        let mut html_depth = 0;
+        for child in node.children() {
+            self.collect_link_text_segments(child, &mut segments, &mut html_depth);
+        }
+        Self::normalize_link_text_segments(segments)
+    }
+
+    fn collect_link_text_segments<'b>(
+        &mut self,
+        node: &'b AstNode<'b>,
+        segments: &mut Vec<LinkTextSegment>,
+        html_depth: &mut usize,
+    ) {
+        match &node.data.borrow().value {
+            NodeValue::Text(_) | NodeValue::SoftBreak => {
+                let mut text = String::new();
+                self.collect_inline_node(node, &mut text);
+                let text = text.replace('\x00', " ");
+                if *html_depth == 0 {
+                    segments.push(LinkTextSegment::Ordinary(text));
+                } else {
+                    segments.push(LinkTextSegment::Verbatim(text));
+                }
+            }
+            NodeValue::Emph => {
+                let delimiter = self.get_emphasis_delimiter(node).to_string();
+                segments.push(LinkTextSegment::Verbatim(delimiter.clone()));
+                for child in node.children() {
+                    self.collect_link_text_segments(child, segments, html_depth);
+                }
+                segments.push(LinkTextSegment::Verbatim(delimiter));
+            }
+            NodeValue::Strong => {
+                let delimiter = self.get_strong_delimiter(node).to_string();
+                segments.push(LinkTextSegment::Verbatim(delimiter.clone()));
+                for child in node.children() {
+                    self.collect_link_text_segments(child, segments, html_depth);
+                }
+                segments.push(LinkTextSegment::Verbatim(delimiter));
+            }
+            NodeValue::HtmlInline(html) => {
+                segments.push(LinkTextSegment::Verbatim(html.clone()));
+                Self::update_inline_html_depth(html, html_depth);
+            }
+            NodeValue::Code(_) | NodeValue::Math(_) | NodeValue::LineBreak => {
+                let mut text = String::new();
+                self.collect_inline_node(node, &mut text);
+                segments.push(LinkTextSegment::Verbatim(text));
+            }
+            NodeValue::Image(_) => {
+                let mut image = String::new();
+                self.collect_inline_node(node, &mut image);
+                segments.push(LinkTextSegment::Verbatim(image));
+            }
+            _ if *html_depth == 0 && node.children().next().is_some() => {
+                for child in node.children() {
+                    self.collect_link_text_segments(child, segments, html_depth);
+                }
+            }
+            _ => {
+                let mut text = String::new();
+                self.collect_inline_node(node, &mut text);
+                segments.push(LinkTextSegment::Verbatim(text));
+            }
+        }
+    }
+
+    fn normalize_link_text_segments(segments: Vec<LinkTextSegment>) -> String {
+        let mut output = String::new();
+        let mut pending_whitespace = String::new();
+        let mut has_content = false;
+
+        for segment in segments {
+            match segment {
+                LinkTextSegment::Ordinary(text) => {
+                    for ch in text.chars() {
+                        if escape::is_commonmark_whitespace(ch) {
+                            pending_whitespace.push(ch);
+                        } else {
+                            Self::flush_link_text_whitespace(
+                                &mut output,
+                                &mut pending_whitespace,
+                                has_content,
+                            );
+                            output.push(ch);
+                            has_content = true;
+                        }
+                    }
+                }
+                LinkTextSegment::Verbatim(text) => {
+                    if !text.is_empty() {
+                        Self::flush_link_text_whitespace(
+                            &mut output,
+                            &mut pending_whitespace,
+                            has_content,
+                        );
+                        output.push_str(&text);
+                        has_content = true;
+                    }
+                }
+            }
+        }
+
+        output.push_str(&pending_whitespace);
+        output
+    }
+
+    fn flush_link_text_whitespace(
+        output: &mut String,
+        pending_whitespace: &mut String,
+        has_content: bool,
+    ) {
+        if pending_whitespace.is_empty() {
+            return;
+        }
+        if has_content {
+            output.push(' ');
+        } else {
+            output.push_str(pending_whitespace);
+        }
+        pending_whitespace.clear();
+    }
+
+    fn update_inline_html_depth(html: &str, depth: &mut usize) {
+        let html = html.trim();
+        if html.starts_with("</") {
+            *depth = depth.saturating_sub(1);
+            return;
+        }
+        if !html.starts_with('<')
+            || html.starts_with("<!")
+            || html.starts_with("<?")
+            || html.ends_with("/>")
+        {
+            return;
+        }
+
+        let tag = html[1..]
+            .chars()
+            .take_while(|ch| ch.is_ascii_alphanumeric() || *ch == '-')
+            .collect::<String>()
+            .to_ascii_lowercase();
+        if !tag.is_empty()
+            && !matches!(
+                tag.as_str(),
+                "area"
+                    | "base"
+                    | "br"
+                    | "col"
+                    | "embed"
+                    | "hr"
+                    | "img"
+                    | "input"
+                    | "link"
+                    | "meta"
+                    | "param"
+                    | "source"
+                    | "track"
+                    | "wbr"
+            )
+        {
+            *depth += 1;
+        }
     }
 
     /// Collect raw text without escaping (for comparison purposes)
@@ -117,14 +297,27 @@ impl<'a> Serializer<'a> {
             }
             NodeValue::Link(link) => {
                 // Handle reference-style links in headings
-                if let Some((_, label)) = self.get_reference_style_info(node) {
+                if Self::contains_image(node) {
+                    let link_text = self.collect_inline_children(node).replace('\x00', " ");
+                    if let Some((_, label)) = self.get_reference_style_info(node) {
+                        self.format_reference_link(
+                            text,
+                            &link_text,
+                            &label,
+                            &link.url,
+                            &link.title,
+                        );
+                    } else {
+                        Self::format_inline_link(text, &link_text, &link.url, &link.title);
+                    }
+                } else if let Some((_, label)) = self.get_reference_style_info(node) {
                     let link_text = self.collect_inline_children(node);
                     self.format_reference_link(text, &link_text, &label, &link.url, &link.title);
                 } else {
                     // For inline links, just output plain text (or format as inline?)
                     // In headings, we typically want reference style for external links
                     if Self::is_external_url(&link.url) {
-                        let link_text = self.collect_inline_children(node);
+                        let link_text = self.collect_normalized_link_text(node);
                         // Headings don't have footnote references as siblings, so no need for collapsed style
                         self.format_external_link_as_reference(
                             text,
@@ -230,9 +423,7 @@ impl<'a> Serializer<'a> {
             }
             NodeValue::Link(link) => {
                 // Check if link contains an image (badge-style link)
-                let contains_image = node
-                    .children()
-                    .any(|child| matches!(&child.data.borrow().value, NodeValue::Image(_)));
+                let contains_image = Self::contains_image(node);
 
                 // Check if this is an autolink (link text equals URL)
                 let raw_text = self.collect_raw_text(node);
@@ -277,7 +468,7 @@ impl<'a> Serializer<'a> {
                     Self::format_autolink(content, &link.url);
                 } else if Self::is_external_url(&link.url) {
                     // External URL: collect link text first
-                    let link_text = self.collect_inline_children(node);
+                    let link_text = self.collect_normalized_link_text(node);
                     // Check if next sibling starts with '[' to decide if we need collapsed style
                     let use_collapsed = Self::next_sibling_starts_with_bracket(node);
                     self.format_external_link_as_reference(

--- a/src/serializer/link.rs
+++ b/src/serializer/link.rs
@@ -156,9 +156,7 @@ impl<'a> Serializer<'a> {
 
     pub(super) fn serialize_link<'b>(&mut self, node: &'b AstNode<'b>, url: &str, title: &str) {
         // Check if link contains an image (badge-style link)
-        let contains_image = node
-            .children()
-            .any(|child| matches!(&child.data.borrow().value, NodeValue::Image(_)));
+        let contains_image = Self::contains_image(node);
 
         // Check if this is an autolink (link text equals URL)
         let raw_text = self.collect_raw_text(node);
@@ -202,7 +200,7 @@ impl<'a> Serializer<'a> {
         } else if is_autolink {
             Self::format_autolink(&mut self.output, url);
         } else if Self::is_external_url(url) {
-            let link_text = self.collect_inline_children(node);
+            let link_text = self.collect_normalized_link_text(node);
             let mut output = String::new();
             let use_collapsed = Self::next_sibling_starts_with_bracket(node);
             self.format_external_link_as_reference(

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -7504,6 +7504,25 @@ fn test_inline_external_link_whitespace_is_normalized() {
 }
 
 #[test]
+fn test_inline_external_link_edge_whitespace_is_normalized() {
+    for (text, displayed) in [("  a", " a"), ("a  ", "a "), ("a\t\t", "a ")] {
+        let input = format!("See [{text}](https://example.com/).\n");
+        let expected = format!(
+            "See [{displayed}][a].\n\n\
+             [a]: https://example.com/\n"
+        );
+
+        let result = parse_and_serialize_with_warnings(&input);
+        assert_eq!(result.output, expected, "failed for {text:?}");
+        assert!(result.warnings.is_empty());
+
+        let second = parse_and_serialize_with_warnings(&result.output);
+        assert_eq!(second.output, result.output);
+        assert!(second.warnings.is_empty());
+    }
+}
+
+#[test]
 fn test_non_ascii_internal_whitespace_is_preserved() {
     for whitespace in ['\u{a0}', '\u{3000}'] {
         let text = format!("a{whitespace}b");

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -3496,6 +3496,32 @@ fn test_heading_with_image_only() {
 }
 
 #[test]
+fn test_heading_link_with_nested_image_stays_inline() {
+    let input = "# Project [**![CI](badge.svg)**](https://ci.example.com/)";
+    let result = parse_and_serialize(input);
+
+    assert!(
+        result.starts_with("Project [**![CI](badge.svg)**](https://ci.example.com/)\n"),
+        "Image-bearing link should stay inline, got:\n{result}"
+    );
+    assert!(!result.contains("[**![CI](badge.svg)**]:"));
+    assert_eq!(parse_and_serialize(&result), result);
+}
+
+#[test]
+fn test_multiline_heading_link_with_nested_image_stays_inline() {
+    let input = "Project [**![CI](badge.svg)**\nbadge](https://ci.example.com/)\n===============================";
+    let result = parse_and_serialize(input);
+
+    assert!(
+        result.starts_with("Project [**![CI](badge.svg)** badge](https://ci.example.com/)\n"),
+        "Soft break should become a space, got:\n{result:?}"
+    );
+    assert!(!result.contains('\0'));
+    assert_eq!(parse_and_serialize(&result), result);
+}
+
+#[test]
 fn test_setext_heading_with_image_on_previous_line() {
     // When image is on a separate line before setext heading text,
     // they form a single heading (per Markdown spec)
@@ -7458,6 +7484,99 @@ fn test_generated_label_normalization_preserves_link_content() {
         assert_eq!(second.output, result.output);
         assert!(second.warnings.is_empty());
     }
+}
+
+#[test]
+fn test_inline_external_link_whitespace_is_normalized() {
+    // https://github.com/dahlia/hongdown/issues/28
+    for text in ["a  b", "a\tb"] {
+        let input = format!("See [{text}](https://example.com/).\n");
+        let expected = "See [a b].\n\n[a b]: https://example.com/\n";
+
+        let result = parse_and_serialize_with_warnings(&input);
+        assert_eq!(result.output, expected, "failed for {text:?}");
+        assert!(result.warnings.is_empty());
+
+        let second = parse_and_serialize_with_warnings(&result.output);
+        assert_eq!(second.output, result.output);
+        assert!(second.warnings.is_empty());
+    }
+}
+
+#[test]
+fn test_non_ascii_internal_whitespace_is_preserved() {
+    for whitespace in ['\u{a0}', '\u{3000}'] {
+        let text = format!("a{whitespace}b");
+        let input = format!("See [{text}](https://example.com/).\n");
+        let expected = format!(
+            "See [{text}][a b].\n\n\
+             [a b]: https://example.com/\n"
+        );
+
+        let result = parse_and_serialize_with_warnings(&input);
+        assert_eq!(
+            result.output, expected,
+            "failed for U+{:04X}",
+            whitespace as u32
+        );
+        assert!(result.warnings.is_empty());
+
+        let second = parse_and_serialize_with_warnings(&result.output);
+        assert_eq!(second.output, result.output);
+        assert!(second.warnings.is_empty());
+    }
+}
+
+#[test]
+fn test_mixed_inline_external_link_whitespace_is_normalized_selectively() {
+    // Whitespace in ordinary text should collapse without changing the
+    // contents of whitespace-sensitive inline constructs.
+    for (text, displayed, label) in [
+        ("a  b `c  d` e  f", "a b `c  d` e f", "a b `c d` e f"),
+        ("a  b $c  d$ e  f", "a b $c  d$ e f", "a b $c d$ e f"),
+        (
+            "a  b <span>c  d</span> e  f",
+            "a b <span>c  d</span> e f",
+            "a b <span>c d</span> e f",
+        ),
+        (
+            "<span>*a  </span>* c  d",
+            "<span>*a  </span>* c d",
+            "<span>*a </span>* c d",
+        ),
+        (
+            "<span>**a  </span>** c  d",
+            "<span>**a  </span>** c d",
+            "<span>**a </span>** c d",
+        ),
+    ] {
+        let input = format!("See [{text}](https://example.com/).\n");
+        let expected = format!(
+            "See [{displayed}][{label}].\n\n\
+             [{label}]: https://example.com/\n"
+        );
+
+        let result = parse_and_serialize_with_warnings(&input);
+        assert_eq!(result.output, expected, "failed for {text:?}");
+        assert!(result.warnings.is_empty());
+
+        let second = parse_and_serialize_with_warnings(&result.output);
+        assert_eq!(second.output, result.output);
+        assert!(second.warnings.is_empty());
+    }
+}
+
+#[test]
+fn test_nested_image_in_external_link_is_preserved() {
+    let input = "See [**![badge](badge.svg)** text](https://example.com/).\n";
+
+    let result = parse_and_serialize_with_warnings(input);
+    assert_eq!(result.output, input);
+    assert!(result.warnings.is_empty());
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert!(second.warnings.is_empty());
 }
 
 #[test]


### PR DESCRIPTION
Fixes #28.


Why this is needed
------------------

Hongdown turns external inline links into reference links.  Before this change, the displayed text and the generated label followed different whitespace paths.  For `[a  b](https://example.com/)`, the first run retained both spaces in the visible text but wrote a definition using the normalized label.  Parsing that output collapsed the link text, so a second run changed it again.  A formatter should reach its stable form on the first run.


How the serializer keeps the right distinctions
-----------------------------------------------

The serializer now walks the inline nodes inside a link and normalizes only ordinary text.  Runs of CommonMark ASCII whitespace become one space.  Code spans, math, inline HTML, hard breaks, and non-ASCII whitespace retain their contents.  HTML element depth is tracked through emphasis and strong spans, so text inside inline HTML is not mistaken for ordinary Markdown text.

Images are handled as complete inline constructs during the same walk. Recursive image detection keeps image-bearing links inline even when the image is nested under emphasis or strong spans, or when the link appears in a heading.  This prevents image syntax from becoming an invalid reference label. In headings, soft breaks become spaces before inline link text is emitted, so the serializer's internal marker cannot reach the output.

Normalizing ordinary text before reference generation gives the displayed text and its label stable ASCII spacing on the first pass.  Separate label normalization can still prepare preserved inline syntax for CommonMark lookup without altering its display.  *STYLE.md* records this boundary.


How this was verified
---------------------

Each edge case was first captured by a failing regression test in *src/serializer/tests.rs*.  The tests cover doubled spaces and tabs, mixed ordinary and whitespace-sensitive content, non-ASCII whitespace, nested images, image-bearing links in headings, and multiline heading links.  They also format the results again to check that the first output is already stable.

The full Rust, WASM, and VS Code test suites pass through `mise run test`. Formatting, Clippy, type checking, Markdown checking, the WASM build, and VS Code type checking pass through `mise run check`.
