### PR TITLE
Preserve reference destination semantics across formatting passes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,14 @@ Version 0.5.2
 
 To be released.
 
+ -  Fixed a bug where reference definitions lost angle brackets required by an
+    empty destination, ASCII whitespace, or other targets that cannot be
+    serialized safely in bare form.  Those lines no longer represented the
+    original CommonMark reference definitions, and a second formatting pass
+    treated them as ordinary text.  These destinations now stay
+    angle-bracketed, preserving their link targets and making formatting
+    idempotent.  [[#25], [#37]]
+
  -  Fixed a bug where an external inline link whose text contained consecutive
     whitespace could require two formatting passes to settle.  Runs of
     CommonMark ASCII whitespace in ordinary link text are now collapsed on the
@@ -89,6 +97,7 @@ To be released.
     out cut short too, so the next run no longer read it as a definition at
     all.  [[#32]]
 
+[#25]: https://github.com/dahlia/hongdown/issues/25
 [#26]: https://github.com/dahlia/hongdown/issues/26
 [#27]: https://github.com/dahlia/hongdown/issues/27
 [#28]: https://github.com/dahlia/hongdown/issues/28
@@ -99,6 +108,7 @@ To be released.
 [#34]: https://github.com/dahlia/hongdown/pull/34
 [#35]: https://github.com/dahlia/hongdown/pull/35
 [#36]: https://github.com/dahlia/hongdown/pull/36
+[#37]: https://github.com/dahlia/hongdown/pull/37
 
 
 Version 0.5.1

--- a/STYLE.md
+++ b/STYLE.md
@@ -363,6 +363,28 @@ Read the [installation guide] before proceeding.
 out of the text flow.  Placing definitions at section end keeps related content
 together.
 
+### Angle brackets for reference destinations
+
+Wrap a reference destination in angle brackets when the bare form would be
+empty, ambiguous, or invalid.  This includes destinations containing ASCII
+whitespace or control characters, destinations beginning with `<`, and
+destinations containing backslashes or text that would be reparsed as a
+character reference.  Also use angle brackets for unbalanced parentheses or
+more than 32 levels of parenthesis nesting.
+
+~~~~ markdown
+[space]: <https://example.com/a b>
+[empty]: <>
+~~~~
+
+Within such a destination, backslash-escape literal angle brackets and
+backslashes.  Write ampersands as `&amp;` and line endings as numeric character
+references.
+
+*Rationale*: Without the angle brackets, whitespace ends the destination and an
+empty destination is not recognized at all.  Keeping these destinations
+angle-bracketed preserves their targets and makes formatting idempotent.
+
 ### Inline style for links containing images
 
 Keep an inline link inline when its text contains an image, even if its

--- a/src/serializer/mod.rs
+++ b/src/serializer/mod.rs
@@ -62,6 +62,37 @@ pub(super) fn find_unescaped(text: &str, delimiter: char) -> Option<usize> {
     None
 }
 
+/// Return whether `url` cannot be emitted as a bare CommonMark destination.
+fn reference_destination_requires_angle_brackets(url: &str) -> bool {
+    if url.is_empty()
+        || url.starts_with('<')
+        || url
+            .bytes()
+            .any(|byte| byte == b' ' || byte.is_ascii_control())
+        || url.contains('\\')
+        || url.contains("&#")
+        || html_escape::decode_html_entities(url).as_ref() != url
+    {
+        return true;
+    }
+
+    let mut parenthesis_depth = 0;
+    for byte in url.bytes() {
+        match byte {
+            b'(' => {
+                parenthesis_depth += 1;
+                if parenthesis_depth > 32 {
+                    return true;
+                }
+            }
+            b')' if parenthesis_depth == 0 => return true,
+            b')' => parenthesis_depth -= 1,
+            _ => {}
+        }
+    }
+    parenthesis_depth != 0
+}
+
 /// Result of serialization including output and any warnings.
 pub struct SerializeResult {
     /// The formatted Markdown output.
@@ -342,7 +373,25 @@ impl<'a> Serializer<'a> {
         // (comrak normalizes whitespace in labels, so this ensures idempotency)
         output.push_str(&reference.label.replace('\x00', " "));
         output.push_str("]: ");
-        output.push_str(&reference.url);
+        if reference_destination_requires_angle_brackets(&reference.url) {
+            output.push('<');
+            for character in reference.url.chars() {
+                match character {
+                    '<' | '>' => {
+                        output.push('\\');
+                        output.push(character);
+                    }
+                    '\\' => output.push_str("\\\\"),
+                    '&' => output.push_str("&amp;"),
+                    '\n' => output.push_str("&#10;"),
+                    '\r' => output.push_str("&#13;"),
+                    _ => output.push(character),
+                }
+            }
+            output.push('>');
+        } else {
+            output.push_str(&reference.url);
+        }
         if !reference.title.is_empty() {
             output.push_str(" \"");
             output.push_str(&reference.title);

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -300,6 +300,110 @@ fn test_serialize_external_link_with_title_becomes_reference() {
 }
 
 #[test]
+fn test_reference_destinations_requiring_angle_brackets() {
+    // https://github.com/dahlia/hongdown/issues/25
+    let input = concat!(
+        " -  Read [space].\n",
+        " -  Read [empty].\n\n",
+        "[space]: <https://example.com/a b> \"A title\"\n",
+        "[empty]: <>\n",
+    );
+    let expected = concat!(
+        " -  Read [space].\n",
+        " -  Read [empty].\n\n",
+        "[space]: <https://example.com/a b> \"A title\"\n",
+        "[empty]: <>\n",
+    );
+
+    let result = parse_and_serialize_with_warnings(input);
+    assert_eq!(result.output, expected);
+    assert!(result.warnings.is_empty());
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert!(second.warnings.is_empty());
+}
+
+#[test]
+fn test_angle_bracketed_reference_destination_escaping_is_idempotent() {
+    let input = concat!(
+        " -  Read [escaped].\n",
+        " -  Read [backslash].\n",
+        " -  Read [entity].\n",
+        " -  Read [line break].\n",
+        " -  Read [carriage return].\n",
+        " -  Read [surrogate].\n",
+        " -  Read [out of range].\n",
+        " -  Read [overflow].\n\n",
+        "[escaped]: <https://example.com/a\\> b>\n",
+        "[backslash]: <https://example.com/a b\\\\*c>\n",
+        "[entity]: <https://example.com/a b&amp;#10;>\n",
+        "[line break]: <https://example.com/a&#10;b>\n",
+        "[carriage return]: <https://example.com/a&#13;b>\n",
+        "[surrogate]: <a&amp;#xD800;b>\n",
+        "[out of range]: <a&amp;#x110000;b>\n",
+        "[overflow]: <a&amp;#99999999;b>\n",
+    );
+
+    let result = parse_and_serialize_with_warnings(input);
+    assert_eq!(result.output, input);
+    assert!(result.warnings.is_empty());
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert!(second.warnings.is_empty());
+}
+
+#[test]
+fn test_reference_destinations_not_safe_bare_use_angle_brackets() {
+    let input = concat!(
+        " -  Read [leading angle].\n",
+        " -  Read [vertical tab].\n",
+        " -  Read [open paren].\n",
+        " -  Read [backslash].\n",
+        " -  Read [entity].\n",
+        " -  Read [balanced].\n\n",
+        "[leading angle]: <\\<foo\\>>\n",
+        "[vertical tab]: <a&#11;b>\n",
+        "[open paren]: <a(b>\n",
+        "[backslash]: <a\\\\*b>\n",
+        "[entity]: <a&amp;#10;>\n",
+        "[balanced]: <a(b)>\n",
+    );
+    let expected = concat!(
+        " -  Read [leading angle].\n",
+        " -  Read [vertical tab].\n",
+        " -  Read [open paren].\n",
+        " -  Read [backslash].\n",
+        " -  Read [entity].\n",
+        " -  Read [balanced].\n\n",
+        "[leading angle]: <\\<foo\\>>\n",
+        "[vertical tab]: <a\u{b}b>\n",
+        "[open paren]: <a(b>\n",
+        "[backslash]: <a\\\\*b>\n",
+        "[entity]: <a&amp;#10;>\n",
+        "[balanced]: a(b)\n",
+    );
+
+    let result = parse_and_serialize_with_warnings(input);
+    assert_eq!(result.output, expected);
+    assert!(result.warnings.is_empty());
+
+    let second = parse_and_serialize_with_warnings(&result.output);
+    assert_eq!(second.output, result.output);
+    assert!(second.warnings.is_empty());
+}
+
+#[test]
+fn test_bare_reference_destination_parenthesis_limit() {
+    let at_limit = format!("a{}{}", "(".repeat(32), ")".repeat(32));
+    assert!(!reference_destination_requires_angle_brackets(&at_limit));
+
+    let beyond_limit = format!("a{}{}", "(".repeat(33), ")".repeat(33));
+    assert!(reference_destination_requires_angle_brackets(&beyond_limit));
+}
+
+#[test]
 fn test_reference_order_preserved() {
     // Regular references should maintain insertion order
     let input = "See [foo](https://foo.com), [bar](https://bar.com), and [baz](https://baz.com).";


### PR DESCRIPTION
Closes #25.


Why
---

CommonMark allows reference destinations that cannot be written safely in bare form. Comrak gives the serializer a decoded destination, so writing that value back without considering the destination grammar can move a space outside the URL, turn an empty definition into ordinary text, or make syntax such as a backslash or character reference change meaning on the next parse.

The first formatting pass could therefore produce Markdown that represented a different link target, while a second pass could change the document again. This violated Hongdown's expectation that formatting preserves meaning and settles after one pass.


Approach
--------

The reference serializer now decides whether the parsed destination can round trip in bare form. It keeps the shorter bare form when CommonMark permits it, and uses angle brackets when the destination is empty, contains whitespace or control characters, begins with `<`, contains syntax that will be reparsed, or crosses CommonMark's parenthesis balance and nesting limits.

Angle brackets alone are not enough because Comrak decodes backslash escapes and character references during parsing. When the bracketed form is needed, the serializer escapes literal angle brackets and backslashes, encodes ampersands, and writes line endings as numeric character references. Parsing the result therefore recovers the same destination instead of decoding it a second time.

The regression tests start with the examples from the issue and compare both the first formatted output and a second formatting pass. Additional cases exercise the grammar boundaries that choose between bare and bracketed forms, including invalid numeric references and the 32-level parenthesis nesting limit. *STYLE.md* records the resulting canonical form, and *CHANGES.md* explains why affected documents no longer need a second pass.