### PR TITLE
Keep shared definitions in the first section that uses them

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,12 @@ Version 0.5.2
 
 To be released.
 
+ -  Fixed a bug where a reference definition shared by a body link and a link
+    inside a footnote could sink to the later footnote's section, leaving the
+    body link's section without its definition.  Shared definitions now stay at
+    the end of the first section that uses them, while remaining below footnote
+    definitions when both occur in the same section.  [[#30], [#38]]
+
  -  Fixed a bug where reference definitions lost angle brackets required by an
     empty destination, ASCII whitespace, or other targets that cannot be
     serialized safely in bare form.  Those lines no longer represented the
@@ -102,6 +108,7 @@ To be released.
 [#27]: https://github.com/dahlia/hongdown/issues/27
 [#28]: https://github.com/dahlia/hongdown/issues/28
 [#29]: https://github.com/dahlia/hongdown/pull/29
+[#30]: https://github.com/dahlia/hongdown/issues/30
 [#31]: https://github.com/dahlia/hongdown/issues/31
 [#32]: https://github.com/dahlia/hongdown/pull/32
 [#33]: https://github.com/dahlia/hongdown/issues/33
@@ -109,6 +116,7 @@ To be released.
 [#35]: https://github.com/dahlia/hongdown/pull/35
 [#36]: https://github.com/dahlia/hongdown/pull/36
 [#37]: https://github.com/dahlia/hongdown/pull/37
+[#38]: https://github.com/dahlia/hongdown/pull/38
 
 
 Version 0.5.1

--- a/STYLE.md
+++ b/STYLE.md
@@ -347,8 +347,8 @@ Links
 
 ### Reference-style for external URLs
 
-Convert external URLs to reference-style links, with definitions placed at
-the end of the current section:
+Convert external URLs to reference-style links, with each definition placed at
+the end of the first section that uses it:
 
 ~~~~ markdown
 See the [documentation] for more details.
@@ -358,6 +358,12 @@ Read the [installation guide] before proceeding.
 [documentation]: https://example.com/docs
 [installation guide]: https://example.com/install
 ~~~~
+
+When several links share a definition, keep it in the first section that uses
+it.  A link inside a footnote belongs to the section where the footnote is
+referenced, regardless of where its definition appears in the source.  If body
+content and one of its footnotes share a definition in the same section, place
+the reference definition after the footnote definition.
 
 *Rationale*: Reference-style links keep the prose readable by moving long URLs
 out of the text flow.  Placing definitions at section end keeps related content

--- a/src/serializer/state.rs
+++ b/src/serializer/state.rs
@@ -821,6 +821,7 @@ impl<'a> Serializer<'a> {
     fn satisfy_shared_reference(&mut self, key: String, label: &str, url: &str, title: &str) {
         if !self.footnotes.collecting_content
             && self.footnotes.pending_references.contains_key(&key)
+            && !self.verbatim_reference_labels.contains(&key)
             && !self.emitted_references.contains_key(&key)
             && !self.pending_references.contains_key(&key)
         {
@@ -969,7 +970,8 @@ impl<'a> Serializer<'a> {
 #[cfg(test)]
 mod tests {
     use super::{
-        REFERENCE_LABEL_REPLACEMENT_SCANS, Serializer, normalize_reference_key, safe_str_slice,
+        REFERENCE_LABEL_REPLACEMENT_SCANS, ReferenceLink, Serializer, normalize_reference_key,
+        safe_str_slice,
     };
     use crate::Options;
 
@@ -1009,6 +1011,29 @@ mod tests {
             "before {expression0} and {expression127} after"
         );
         REFERENCE_LABEL_REPLACEMENT_SCANS.with(|scans| assert_eq!(scans.get(), 2));
+    }
+
+    #[test]
+    fn shared_reference_carried_verbatim_is_not_queued() {
+        let options = Options::default();
+        let mut serializer = Serializer::new(&options, Vec::new(), false);
+        let key = serializer.reference_key("guide");
+        serializer.footnotes.pending_references.insert(
+            key.clone(),
+            (
+                ReferenceLink {
+                    label: "guide".to_string(),
+                    url: "https://example.com/guide".to_string(),
+                    title: String::new(),
+                },
+                1,
+            ),
+        );
+        serializer.verbatim_reference_labels.insert(key.clone());
+
+        serializer.satisfy_shared_reference(key.clone(), "guide", "https://example.com/guide", "");
+
+        assert!(!serializer.pending_references.contains_key(&key));
     }
 
     #[test]

--- a/src/serializer/state.rs
+++ b/src/serializer/state.rs
@@ -731,13 +731,13 @@ impl<'a> Serializer<'a> {
             .find_occupant(&key)
             .map(|existing| (existing.url.clone(), existing.title.clone()));
         match occupant {
-            // Already registered with the same target: share it.  The existing
-            // entry is left untouched so that its spelling (and, once emitted,
-            // its definition) is not duplicated or altered.
+            // Already registered with the same target: share it.  A body link
+            // may still need to queue the definition for its section when the
+            // existing entry belongs to a later footnote's schedule.
             Some((occupied_url, occupied_title))
                 if occupied_url == url && occupied_title == title =>
             {
-                self.satisfy_claimed_label(key, label, url, title);
+                self.satisfy_shared_reference(key, label, url, title);
                 label.to_string()
             }
             // Free label: take it.
@@ -758,8 +758,10 @@ impl<'a> Serializer<'a> {
                 // Looking it up directly keeps a document full of same-text
                 // links from rescanning every variant it has handed out.
                 let target = (cursor_key.clone(), url.to_string(), title.to_string());
-                if let Some(label) = self.numbered_reference_labels.get(&target) {
-                    return label.clone();
+                if let Some(label) = self.numbered_reference_labels.get(&target).cloned() {
+                    let key = self.reference_key(&label);
+                    self.satisfy_shared_reference(key, &label, url, title);
+                    return label;
                 }
                 // Every variant below the cursor is already taken, and taken
                 // labels are never released, so the search can resume there.
@@ -796,7 +798,7 @@ impl<'a> Serializer<'a> {
                         None if self.is_numbered_label_unavailable(&candidate_key) => continue,
                         // Already holds this very target: share it.
                         Some(_) => {
-                            self.satisfy_claimed_label(candidate_key, &candidate, url, title)
+                            self.satisfy_shared_reference(candidate_key, &candidate, url, title)
                         }
                         None => self.insert_reference(candidate_key, candidate.clone(), url, title),
                     }
@@ -810,14 +812,21 @@ impl<'a> Serializer<'a> {
         }
     }
 
-    /// Register a definition for a label that so far is only *claimed*.
+    /// Ensure a shared reference is scheduled where the current link needs it.
     ///
-    /// A claim marks the label as spoken for by a link preserved verbatim, but
-    /// emits no definition of its own, so a formatted link sharing that label
-    /// still has to supply one.  The exception is a label whose definition is
-    /// preserved verbatim too: that copy already defines it, and adding another
-    /// would merely repeat it.
-    fn satisfy_claimed_label(&mut self, key: String, label: &str, url: &str, title: &str) {
+    /// Footnotes are collected before the body.  If a later footnote registered
+    /// the target first, a body link still needs the definition queued for its
+    /// own section.  A label only claimed by a verbatim link likewise needs a
+    /// definition, unless the definition itself is preserved verbatim.
+    fn satisfy_shared_reference(&mut self, key: String, label: &str, url: &str, title: &str) {
+        if !self.footnotes.collecting_content
+            && self.footnotes.pending_references.contains_key(&key)
+            && !self.emitted_references.contains_key(&key)
+            && !self.pending_references.contains_key(&key)
+        {
+            self.insert_reference(key, label.to_string(), url, title);
+            return;
+        }
         if self.find_reference(&key).is_none() && !self.verbatim_reference_labels.contains(&key) {
             self.insert_reference(key, label.to_string(), url, title);
         }

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -4092,6 +4092,150 @@ More content here.
 }
 
 #[test]
+fn test_body_reference_shared_with_later_footnote_stays_in_body_section() {
+    let input = r#"Section one
+-----------
+
+Body [guide] link.
+
+Section two
+-----------
+
+Text with a footnote[^1].
+
+[^1]: See [guide] as well.
+
+[guide]: https://example.com/guide
+"#;
+    let result = parse_and_serialize(input);
+
+    assert_eq!(
+        result,
+        r#"Section one
+-----------
+
+Body [guide] link.
+
+[guide]: https://example.com/guide
+
+
+Section two
+-----------
+
+Text with a footnote[^1].
+
+[^1]: See [guide] as well.
+"#
+    );
+}
+
+#[test]
+fn test_numbered_body_reference_shared_with_later_footnote_stays_in_body_section() {
+    let input = r#"Section one
+-----------
+
+Body [guide](https://example.com/b) link.
+
+Section two
+-----------
+
+Text with a footnote[^1].
+
+[^1]: Compare [guide](https://example.com/a) and [guide](https://example.com/b).
+"#;
+    let result = parse_and_serialize(input);
+    let expected = r#"Section one
+-----------
+
+Body [guide][guide 2] link.
+
+[guide 2]: https://example.com/b
+
+
+Section two
+-----------
+
+Text with a footnote[^1].
+
+[^1]: Compare [guide] and [guide][guide 2].
+
+[guide]: https://example.com/a
+"#;
+
+    assert_eq!(result, expected);
+    assert_eq!(parse_and_serialize(&result), expected);
+}
+
+#[test]
+fn test_shared_reference_stays_below_footnote_in_same_section() {
+    let input = r#"Section
+-------
+
+Body [shared] link with a footnote[^1].
+
+[^1]: See [other] and [shared].
+
+[other]: https://example.com/other
+[shared]: https://example.com/shared
+"#;
+    let result = parse_and_serialize(input);
+    let expected = r#"Section
+-------
+
+Body [shared] link with a footnote[^1].
+
+[^1]: See [other] and [shared].
+
+[shared]: https://example.com/shared
+
+[other]: https://example.com/other
+"#;
+
+    assert_eq!(result, expected);
+    assert_eq!(parse_and_serialize(&result), expected);
+}
+
+#[test]
+fn test_reference_shared_by_footnotes_stays_in_first_section() {
+    let input = r#"Section one
+-----------
+
+First footnote[^a].
+
+Section two
+-----------
+
+Second footnote[^b].
+
+[^b]: Later [guide].
+[^a]: Earlier [guide].
+
+[guide]: https://example.com/guide
+"#;
+    let result = parse_and_serialize(input);
+    let expected = r#"Section one
+-----------
+
+First footnote[^a].
+
+[^a]: Earlier [guide].
+
+[guide]: https://example.com/guide
+
+
+Section two
+-----------
+
+Second footnote[^b].
+
+[^b]: Later [guide].
+"#;
+
+    assert_eq!(result, expected);
+    assert_eq!(parse_and_serialize(&result), expected);
+}
+
+#[test]
 fn test_preserve_html_entities() {
     // HTML entities like &lt; and &gt; should be preserved, not decoded
     let input = "HTML에는 &lt;strong&gt;태그 등 여러 가지 태그가 있습니다.";

--- a/src/serializer/tests.rs
+++ b/src/serializer/tests.rs
@@ -4108,10 +4108,7 @@ Text with a footnote[^1].
 [guide]: https://example.com/guide
 "#;
     let result = parse_and_serialize(input);
-
-    assert_eq!(
-        result,
-        r#"Section one
+    let expected = r#"Section one
 -----------
 
 Body [guide] link.
@@ -4125,8 +4122,10 @@ Section two
 Text with a footnote[^1].
 
 [^1]: See [guide] as well.
-"#
-    );
+"#;
+
+    assert_eq!(result, expected);
+    assert_eq!(parse_and_serialize(&result), expected);
 }
 
 #[test]


### PR DESCRIPTION
A reference definition belongs to the section that first needs it.  That invariant was broken by the way footnotes are prepared: their definitions are serialized before the body, so a link inside a later footnote could reserve a label before an earlier body link was visited.  The link still resolved at document scope, but its definition followed the footnote's schedule and sank into the later section.

This keeps label sharing while separating identity from placement.  When a body link shares a target that is waiting on a footnote, the serializer also queues the definition for the body link's section.  The normal flush order lets that earlier section emit it first, then the emitted-reference tracking discards the later scheduled copy.  The same path handles direct labels, numbered labels reused from the cache, and numbered labels found during collision search.

Relabeling the body link or stopping references from being shared would avoid the scheduling conflict, but it would weaken the existing deduplication and collision rules.  The narrower fix lets every link keep the label chosen by those rules while the first applicable section controls where the one definition is written.  Footnote definitions still flush before link reference definitions in the same section, as the style guide requires.

Tests exercise direct shared labels, numbered labels produced by collisions, same-section footnote ordering, and definitions shared across footnotes.  Cases whose output order can change are formatted twice, since this regression could otherwise hide until a second pass.

Closes #30.